### PR TITLE
Added missing Python module 'six'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ premailer==2.9.6
 psycopg2==2.6.1
 Pygments==2.0.2
 requests==2.8.1
+six==1.10.0


### PR DESCRIPTION
While running on my local machine I got missing python module.
```
(hc-venv)08:17:29 (master) ~/webapps/healthchecks$ ./manage.py migrate
/home/piokie/webapps/healthchecks/hc/settings.py:131: UserWarning: local_settings.py not found, using defaults
  warnings.warn("local_settings.py not found, using defaults")
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/django/core/management/__init__.py", line 351, in execute_from_command_line
    utility.execute()
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/django/core/management/__init__.py", line 325, in execute
    django.setup()
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/django/__init__.py", line 18, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models(all_models)
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/django/apps/config.py", line 198, in import_models
    self.models_module = import_module(models_module_name)
  File "/home/piokie/webapps/hc-venv/lib/python3.4/importlib/__init__.py", line 109, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 2254, in _gcd_import
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/compressor/models.py", line 1, in <module>
    from compressor.conf import CompressorConf  # noqa
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/compressor/conf.py", line 6, in <module>
    from appconf import AppConf
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/appconf/__init__.py", line 2, in <module>
    from .base import AppConf  # noqa
  File "/home/piokie/webapps/hc-venv/lib/python3.4/site-packages/appconf/base.py", line 3, in <module>
    import six
ImportError: No module named 'six'
```

After installation with
```
pip install six
```
It does simply work.