### PR TITLE
make welcome code logic resilient

### DIFF
--- a/hc/front/tests/test_basics.py
+++ b/hc/front/tests/test_basics.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from hc.api.models import Check
 
 
 class BasicsTestCase(TestCase):
@@ -6,3 +7,15 @@ class BasicsTestCase(TestCase):
     def test_it_shows_welcome(self):
         r = self.client.get("/")
         self.assertContains(r, "Get Notified", status_code=200)
+
+    def test_welcome_code(self):
+        r = self.client.get("/")
+        code = self.client.session["welcome_code"]
+        assert Check.objects.filter(code=code).exists()
+
+        self.client.session["welcome_code"] = "x"
+        r = self.client.get("/")
+        code = self.client.session["welcome_code"]
+        assert r.status_code == 200
+        assert code != "x"
+        assert Check.objects.filter(code=code).exists()

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -27,14 +27,16 @@ def index(request):
     if request.user.is_authenticated():
         return redirect("hc-checks")
 
-    if "welcome_code" not in request.session:
+    check = None
+    if "welcome_code" in request.session:
+        code = request.session["welcome_code"]
+        check = Check.objects.filter(code=code).first()
+
+    if check is None:
         check = Check()
         check.save()
         code = str(check.code)
         request.session["welcome_code"] = code
-    else:
-        code = request.session["welcome_code"]
-        check = Check.objects.get(code=code)
 
     ctx = {
         "page": "welcome",


### PR DESCRIPTION
if the temporary code ever disappears, you don't want the user to get stuck on the welcome screen
with tests