### PR TITLE
redirect already logged in user

### DIFF
--- a/hc/accounts/views.py
+++ b/hc/accounts/views.py
@@ -90,6 +90,10 @@ def login_link_sent(request):
 
 
 def check_token(request, username, token):
+    if request.user.is_authenticated() and request.user.username == username:
+        # User is already logged in
+        return redirect("hc-checks")
+
     user = authenticate(username=username, password=token)
     if user is not None:
         if user.is_active:

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -162,8 +162,9 @@ def log(request, code):
     # Now go through pings, calculate time gaps, and decorate
     # the pings list for convenient use in template
     wrapped = []
+    now = timezone.now()
     for i, ping in enumerate(pings):
-        prev = timezone.now() if i == 0 else pings[i - 1].created
+        prev = now if i == 0 else pings[i - 1].created
 
         duration = prev - ping.created
         if duration > check.timeout:


### PR DESCRIPTION
If the user is already logged in, and then click the login email again, they get hit with this:
![image](https://cloud.githubusercontent.com/assets/380950/11450960/f6543ff0-9567-11e5-8554-9fc589807f49.png)

The reason is that their login token has been reset already, but they do have a valid session at the moment.

Correct behavior is to redirect the user to the checks screen instead.

and a small perf change that I saw while reading through the code