### PR TITLE
fixed 50% width for the location column

### DIFF
--- a/static/css/my_checks_desktop.css
+++ b/static/css/my_checks_desktop.css
@@ -17,6 +17,10 @@ table.table tr > th.th-name {
     padding-left: 21px;
 }
 
+table.table tr > th.th-location {
+    width: 50%;
+}
+
 #checks-table .indicator-cell {
     text-align: center;
 }

--- a/templates/front/my_checks_desktop.html
+++ b/templates/front/my_checks_desktop.html
@@ -4,7 +4,7 @@
     <tr>
         <th></th>
         <th class="th-name">Name</th>
-        <th>
+        <th class="th-location">
             <a id="show-urls" class="active" href="#">URL</a>
             <a id="show-emails" href="#">Email</a>
         </th>


### PR DESCRIPTION
give the check location column a fixed 50% width so that when you switch between URL and Email, the column sizing doesn't change
![image](https://cloud.githubusercontent.com/assets/380950/11912362/6d3bcdf4-a5ee-11e5-8d4a-14776b9ecdf4.png)
![image](https://cloud.githubusercontent.com/assets/380950/11912364/7454c29e-a5ee-11e5-8d58-f38802331bd4.png)