### PR TITLE
dont include tests in coverage calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ env:
 addons:
   postgresql: "9.4"
 script:
-  - coverage run --source=hc manage.py test
+  - coverage run --omit=*/tests/* --source=hc manage.py test
 after_success: coveralls
 cache: pip


### PR DESCRIPTION
I noticed that in coverall, the test files were counting towards code coverage
tests should be excluded from coverage information