### PR TITLE
defer inserting the password field into the dom

### DIFF
--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,7 +1,9 @@
 $(function () {
+    var passwordInput = $("#password-block input");
+    passwordInput.detach();
     $("#password-toggle").click(function() {
         $("#password-toggle").hide();
         $("#password-block").removeClass("hide");
+        $("#password-block .input-group").append(passwordInput);
     });
-
 });


### PR DESCRIPTION
the password input field is hidden in the DOM, but that still means password managers will pick it up and insert into a password to use

if I have a password manager with multiple accounts + passwords, this can screw up the login experience

if the password input field is ONLY inserted into the DOM after the toggle has been checked, then the password managers will not be tricked.

I know this is an edge case with how browser password managers work, but the way I fixed it doesn't cause any interaction flow to existing users.