### PR TITLE
forwarded for and forwarded protocol

### DIFF
--- a/hc/api/urls.py
+++ b/hc/api/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+
 from hc.api import views
 
 urlpatterns = [


### PR DESCRIPTION
when an incoming http request comes through a proxy, it will get the header `HTTP_X_FORWARDED_FOR` and `HTTP_X_FORWARDED_PROTO`

see protocol information https://en.wikipedia.org/wiki/X-Forwarded-For

The `ping` API should also hard enforce that its response not be cached so that any proxy in between don't screw it up.