### PR TITLE
remove channel should always redirect even if removal fails

### DIFF
--- a/hc/front/tests/test_remove_channel.py
+++ b/hc/front/tests/test_remove_channel.py
@@ -45,4 +45,4 @@ class RemoveChannelTestCase(BaseTestCase):
 
         self.client.login(username="alice@example.org", password="password")
         r = self.client.post(url)
-        assert r.status_code == 404
+        assert r.status_code == 302

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -336,11 +336,11 @@ def verify_email(request, code, token):
 def remove_channel(request, code):
     assert request.method == "POST"
 
-    channel = get_object_or_404(Channel, code=code)
-    if channel.user != request.user:
-        return HttpResponseForbidden()
-
-    channel.delete()
+    channel = Channel.objects.filter(code=code).first()
+    if channel:
+        if channel.user != request.user:
+            return HttpResponseForbidden()
+        channel.delete()
 
     return redirect("hc-channels")
 

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -336,6 +336,7 @@ def verify_email(request, code, token):
 def remove_channel(request, code):
     assert request.method == "POST"
 
+    # user may refresh the page during POST and cause two deletion attempts
     channel = Channel.objects.filter(code=code).first()
     if channel:
         if channel.user != request.user:


### PR DESCRIPTION
removing the channel may be a slow operation and if the user refresh in the middle of the request, Chrome will make a 2nd POST request, which will end up erroring

I think it's better to always redirect the user to the channel list regardless of whether the removal UUID was valid or not, better than showing an error page if the user sends two removals simultaneously