### PR TITLE
Add healthcheck UA to inform server about identity

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -139,7 +139,8 @@ class Channel(models.Model):
             n.save()
         elif self.kind == "webhook" and check.status == "down":
             try:
-                r = requests.get(self.value, timeout=5)
+                headers = {"User-Agent": "healthchecks.io"}
+                r = requests.get(self.value, timeout=5, headers=headers)
                 n.status = r.status_code
             except requests.exceptions.Timeout:
                 # Well, we tried

--- a/hc/api/tests/test_notify.py
+++ b/hc/api/tests/test_notify.py
@@ -26,7 +26,9 @@ class NotifyTestCase(BaseTestCase):
         mock_get.return_value.status_code = 200
 
         self.channel.notify(self.check)
-        mock_get.assert_called_with(u"http://example", timeout=5)
+        mock_get.assert_called_with(
+            u"http://example", headers={"User-Agent": "healthchecks.io"},
+            timeout=5)
 
     @patch("hc.api.models.requests.get", side_effect=ReadTimeout)
     def test_webhooks_handle_timeouts(self, mock_get):


### PR DESCRIPTION
Adding "healthcheck.io" as User-Agent to inform webhook handler server about request is specific from healthcheck.