### PR TITLE
Proposed change from SSH to HTTPS in installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ in development environment.
 
 * check out project code:
 
-        $ git clone git@github.com:healthchecks/healthchecks.git
+        $ git clone https://github.com/healthchecks/healthchecks.git
 
 * install requirements (Django, ...) into virtualenv:
 


### PR DESCRIPTION
SSH based cloning of the healthchecks repo doesn't work for users who do not have their keys added, resulting in a `Permission denied (publickey)` error. However, HTTPS cloning does work as expected.