### PR TITLE
Using backend name django.db.backends.postgresql

### DIFF
--- a/hc/settings.py
+++ b/hc/settings.py
@@ -93,7 +93,7 @@ DATABASES = {
 if os.environ.get("DB") == "postgres":
     DATABASES = {
         'default': {
-            'ENGINE':   'django.db.backends.postgresql_psycopg2',
+            'ENGINE':   'django.db.backends.postgresql',
             'NAME':     'hc',
             'USER':     'postgres',
             'TEST': {'CHARSET': 'UTF8'}


### PR DESCRIPTION
Using new backend name which come with Django 1.9 django.db.backends.postgresql instead of django.db.backends.postgresql_psycopg2