### PR TITLE
Implement GET /api/v1/checks/ for listing existing checks

### DIFF
--- a/hc/api/tests/test_list_checks.py
+++ b/hc/api/tests/test_list_checks.py
@@ -1,0 +1,48 @@
+import json
+from datetime import timedelta as td
+
+from hc.api.models import Check, User
+from hc.test import BaseTestCase
+from hc.accounts.models import Profile
+
+class ListChecksTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(ListChecksTestCase, self).setUp()
+        self.profile = Profile(user=self.alice, api_key="abc")
+        self.profile.save()
+        self.checks = [
+            Check(user=self.alice, name="Alice 1", timeout=td(seconds=3600), grace=td(seconds=900)),
+            Check(user=self.alice, name="Alice 2", timeout=td(seconds=86400), grace=td(seconds=3600)),
+        ]
+        for check in self.checks:
+            check.save()
+
+    def get(self, url, data):
+        return self.client.generic('GET', url, json.dumps(data), 'application/json')
+
+    def test_it_works(self):
+        r = self.get("/api/v1/checks/", { "api_key": "abc" })
+
+        self.assertEqual(r.status_code, 200)
+        self.assertTrue("checks" in r.json())
+        self.assertEqual(len(r.json()["checks"]), 2)
+
+        checks = { check["name"]: check for check in r.json()["checks"] }
+        self.assertEqual(checks["Alice 1"]["timeout"], 3600)
+        self.assertEqual(checks["Alice 1"]["grace"],   900)
+        self.assertEqual(checks["Alice 1"]["url"],     self.checks[0].url())
+        self.assertEqual(checks["Alice 2"]["timeout"], 86400)
+        self.assertEqual(checks["Alice 2"]["grace"],   3600)
+        self.assertEqual(checks["Alice 2"]["url"],     self.checks[1].url())
+
+    def test_it_shows_only_users_checks(self):
+        bob = User(username="bob", email="bob@example.com")
+        bob.save()
+        bob_check = Check(user=bob, name="Bob 1")
+
+        r = self.get("/api/v1/checks/", { "api_key": "abc" })
+
+        self.assertEqual(len(r.json()["checks"]), 2)
+        checks = { check["name"]: check for check in r.json()["checks"] }
+        self.assertNotIn("Bob 1", checks)

--- a/templates/front/docs_api.html
+++ b/templates/front/docs_api.html
@@ -8,7 +8,7 @@
 <h2>REST API</h2>
 <p>
 This is early days for healtchecks.io REST API. For now, there's just
-one API call: for creating a new check.
+one API resource for listing/creating checks.
 </p>
 
 <h2 class="rule">Authentication</h2>
@@ -41,6 +41,26 @@ and 5xx indicates a server error.
 <p>
 The response may contain a JSON document with additional data.
 </p>
+
+<h2 class="rule">List checks</h2>
+
+<div class="api-path">GET {{ SITE_ROOT }}/api/v1/checks/</div>
+
+<p>
+    Returns a list of checks
+</p>
+<h3 class="api-section">Example Request</h3>
+
+<pre>
+curl {{ SITE_ROOT }}/api/v1/checks/ \
+    -X GET \
+    -d '{"api_key": "your-api-key"}'
+</pre>
+
+<h3 class="api-section">Example Response</h3>
+<pre>
+{"checks": [{"url": "{{ PING_ENDPOINT }}848f3002-266b-482a-89ad-9d66a11aa2fb", "grace": 900, "name": "API test 1", "timeout": 3600, "tags": "foo"}, {"url": "{{ PING_ENDPOINT }}20324f81-5966-4e75-9734-8440df52ed75", "grace": 60, "name": "API test 2", "timeout": 60, "tags": "bar,baz"}]}
+</pre>
 
 <h2 class="rule">Create a check</h2>
 


### PR DESCRIPTION
Another sort-of-rough-draft pull request for allowing an API client to obtain a list of existing checks.  It's missing the list of channels and probably some bullet-proofing.