### PR TITLE
Add Dockerfile to main repository

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.md
+*.yml
+.git/
+.gitignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM python:3-alpine
+
+# Caching layer with bash, tini, UWSGI and mysql / pg clients
+RUN set -ex \
+  && apk add --no-cache mariadb-libs mariadb-client-libs postgresql-libs tini bash \
+  && apk add --no-cache --virtual .build-deps \
+    gcc \
+    # uwsgi needs linux headers
+    linux-headers \
+    # pip install needs py3 & musl dev
+    python3-dev \
+    musl-dev \
+    mariadb-dev \
+    postgresql-dev\
+  && pip3 install --no-cache-dir uwsgi mysqlclient psycopg2==2.6.2 \
+  && apk del .build-deps
+
+# Add hc user
+RUN adduser -D -u 1000 hc
+
+# Install app requirements
+COPY requirements.txt /usr/src/app/
+WORKDIR /usr/src/app/
+RUN set -ex \
+  && apk add --no-cache --virtual .build-deps \
+    gcc \
+    python3-dev \
+    musl-dev \
+  && pip3 install braintree \
+  && pip3 install --no-cache-dir -r requirements.txt \
+  && apk del .build-deps
+
+
+# Copy application source
+COPY . /usr/src/app
+
+# Read settings from env vars
+RUN cp hc/local_settings.py.docker hc/local_settings.py
+
+# Pre-compile assets
+RUN set -ex \
+  && ./manage.py collectstatic --no-input \
+  && ./manage.py compress \
+  && chown -R hc:hc /usr/src/app
+
+EXPOSE 9090
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
+CMD [ "/usr/src/app/bin/uwsgi-start.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.4-alpine
 
 # Caching layer with bash, tini, UWSGI and mysql / pg clients
 RUN set -ex \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/healthchecks/healthchecks.svg?branch=master)](https://travis-ci.org/healthchecks/healthchecks)
 [![Coverage Status](https://coveralls.io/repos/healthchecks/healthchecks/badge.svg?branch=master&service=github)](https://coveralls.io/github/healthchecks/healthchecks?branch=master)
+[![Docker Repository on Quay](https://quay.io/repository/honestbee/healthchecks/status "Docker Repository on Quay")](https://quay.io/repository/honestbee/healthchecks)
 
 
 ![Screenshot of Welcome page](/stuff/screenshots/welcome.png?raw=true "Welcome Page")
@@ -22,7 +23,86 @@ The building blocks are:
 * Django 1.9
 * PostgreSQL or MySQL
 
-## Setting Up for Development
+## Docker quick start
+
+Quick start:
+
+1. [Get Docker](https://store.docker.com/search?offering=community&platform=desktop&q=&type=edition)
+
+1. Start full stack using `docker-compose`:
+```bash
+curl -Lo docker-compose.yaml https://raw.githubusercontent.com/honestbee/healthchecks/master/docker-compose.yml
+docker-compose -p healthchecks up -d
+# monitor boot process of healthchecks app
+docker-compose -p healthchecks logs -f hc
+
+# once ready:
+# open healthchecks on localhost
+open http://localhost:9090
+
+# open mailhog for testing
+open http://localhost:8025
+```
+
+To deploy the application, set environment variables
+
+## Admin Access
+
+By default no admin user is created. To create your first admin user connect to your running docker container:
+
+```bash
+docker-compose -p healthchecks exec hc bash
+```
+
+and run:
+```bash
+./manage.py createsuperuser
+```
+
+You will now be able to login to the admin at http://localhost:9090/admin.
+
+*N.B.* There is no validation so ensure you correctly set an email address and password or you may find yourself unable to login.
+
+## Configuration
+
+The Docker images are built to take basic configuration from environment variables:
+
+| Variable                      | Default                      |
+| ----------------------------- | ---------------------------- |
+| `HEALTHCHECKS_DEBUG`          | `False`                      |
+| `HEALTHCHECKS_HOST`           | `localhost`                  |
+| `HEALTHCHECKS_SITE_ROOT`      | `"http://localhost:9090"`    |
+| `HEALTHCHECKS_DB`             | `mysql`                      |
+| `HEALTHCHECKS_DB_HOST`        | `localhost`                  |
+| `HEALTHCHECKS_DB_USER`        | `root`                       |
+| `HEALTHCHECKS_DB_PASSWORD`    | `pa55word`                   |
+| `HEALTHCHECKS_EMAIL_FROM`     | `"healthchecks@example.org"` |
+| `HEALTHCHECKS_EMAIL_HOST`     | `localhost`                  |
+| `HEALTHCHECKS_EMAIL_PORT`     | `25`                         |
+| `HEALTHCHECKS_EMAIL_USER`     | `""`                         |
+| `HEALTHCHECKS_EMAIL_PASSWORD` | `""`                         |
+| `MYSQL_ROOT_PASSWORD`         | `pa55word`                   |
+| `MYSQL_USER`                  | `hc`                         |
+| `MYSQL_PASSWORD`              | `pa55word`                   |
+| `MYSQL_DATABASE`              | `hc`                         |
+
+Docker Compose can take environment varialbes from [env_files](https://docs.docker.com/compose/compose-file/#envfile) or overwritten using the `-f docker-compose.production.yaml` flag (refer to [docker-compose documentation](https://docs.docker.com/compose/reference/overview/))
+
+Review the configuration with:
+
+```bash
+docker-compose config
+```
+
+## Building
+
+The following command will build the application with the image tag specified in the `docker-compose.yaml` file.
+
+```
+docker-compose build
+```
+
+## Setting Up for Local Development
 
 These are instructions for setting up HealthChecks Django app
 in development environment.

--- a/bin/uwsgi-start.sh
+++ b/bin/uwsgi-start.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -ex
+
+# wait for database connection to run migration
+while ! ./manage.py migrate 2>&1; do
+    sleep 5
+done
+
+#replace bash with uwsgi
+exec uwsgi --master \
+    --uid hc \
+    --gid hc \
+    --http-socket 0.0.0.0:9090 \
+    --processes 2 \
+    --threads 2 \
+    --chdir /usr/src/app \
+    --module hc.wsgi:application \
+    --enable-threads \
+    --thunder-lock \
+    --static-map /static=/usr/src/app/static-collected \
+    --attach-daemon "./manage.py sendalerts"

--- a/bin/uwsgi-start.sh
+++ b/bin/uwsgi-start.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+
+# source: https://github.com/haswalt/docker-healthchecks
 set -ex
 
 # wait for database connection to run migration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# source - https://github.com/haswalt/docker-healthchecks
 version: '2'
 services:
   hc:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   hc:
     build: .
     # image: haswalt/docker-healthchecks
-    image: quay.io/honestbee/healthcheck:latest
+    image: quay.io/honestbee/healthchecks:latest
     ports:
       - "9090:9090"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '2'
+services:
+  hc:
+    build: .
+    # image: haswalt/docker-healthchecks
+    image: quay.io/honestbee/healthcheck:latest
+    ports:
+      - "9090:9090"
+    depends_on:
+      - db
+    environment:
+      HEALTHCHECKS_EMAIL_HOST: mailhog
+      HEALTHCHECKS_EMAIL_PORT: 1025
+      HEALTHCHECKS_DB: mysql
+      HEALTHCHECKS_DB_HOST: db
+      HEALTHCHECKS_DB_USER: root
+      HEALTHCHECKS_DB_PASSWORD: pa55word
+      HEALTHCHECKS_SITE_ROOT: http://localhost:9090
+      HEALTHCHECKS_DEBUG: 1
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "8025:8025"
+  db:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: pa55word
+      MYSQL_USER: hc
+      MYSQL_PASSWORD: pa55word
+      MYSQL_DATABASE: hc

--- a/hc/local_settings.py.docker
+++ b/hc/local_settings.py.docker
@@ -1,0 +1,42 @@
+"""
+Local settings for the HealthChecks app
+"""
+
+import os
+
+ALLOWED_HOSTS = ['*']
+DEBUG = os.getenv('HEALTHCHECKS_DEBUG', False)
+
+HOST = os.getenv('HEALTHCHECKS_HOST', "localhost")
+SITE_ROOT = os.getenv('HEALTHCHECKS_SITE_ROOT', "http://localhost:9090")
+PING_ENDPOINT = SITE_ROOT + "/ping/"
+
+DEFAULT_FROM_EMAIL = os.getenv('HEALTHCHECKS_EMAIL_FROM', "healthchecks@example.org")
+EMAIL_HOST = os.getenv('HEALTHCHECKS_EMAIL_HOST', "localhost")
+EMAIL_PORT = os.getenv('HEALTHCHECKS_EMAIL_PORT', 25)
+EMAIL_HOST_USER = os.getenv('HEALTHCHECKS_EMAIL_USER', "")
+EMAIL_HOST_PASSWORD = os.getenv('HEALTHCHECKS_EMAIL_PASSWORD', "")
+
+if os.environ.get("HEALTHCHECKS_DB") == "postgres":
+    DATABASES = {
+        'default': {
+            'ENGINE':   'django.db.backends.postgresql',
+            'NAME':     os.getenv("HEALTHCHECKS_DB_NAME", "hc"),
+            'USER':     os.getenv('HEALTHCHECKS_DB_USER', "postgres"),
+            'PASSWORD': os.getenv('HEALTHCHECKS_DB_PASSWORD', ""),
+            'HOST':     os.getenv('HEALTHCHECKS_DB_HOST', "localhost"),
+            'TEST': {'CHARSET': 'UTF8'}
+        }
+    }
+
+if os.environ.get("HEALTHCHECKS_DB") == "mysql":
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'USER':     os.getenv('HEALTHCHECKS_DB_USER', "root"),
+            'PASSWORD': os.getenv('HEALTHCHECKS_DB_PASSWORD', ""),
+            'NAME':     os.getenv("HEALTHCHECKS_DB_NAME", "hc"),
+            'HOST': os.getenv('HEALTHCHECKS_DB_HOST', "localhost"),
+            'TEST': {'CHARSET': 'UTF8'}
+        }
+    }


### PR DESCRIPTION
I suggest to include Dockerfile to main repository.

If you agree, I will remove the references to the honestbee image on quay.io and you can add references to the official docker registry you want to push the builds to.

Edit: Checklist
- [x] Rebase on official python (alpine)
- [x] Add tini process reaper
- [ ] Add option to entrypoint bash script to attach the send-alert process to uwsgi daemon
- [ ] Verify all assets are served properly 
  I noticed some admin UI buttons seemed to have gone missing, could be because of asset compilation needs hostname?
- [ ] Find a way to get rid of `chown -R hc:hc /usr/src/app`
- [ ] reconsider using `gosu`