### PR TITLE
Return consistent date formats in API

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -167,8 +167,8 @@ class Check(models.Model):
             result["tz"] = self.tz
 
         if self.last_ping:
-            result["last_ping"] = self.last_ping.isoformat()
-            result["next_ping"] = (self.last_ping + self.timeout).isoformat()
+            result["last_ping"] = self.last_ping.replace(microsecond=0).isoformat()
+            result["next_ping"] = (self.last_ping + self.timeout).replace(microsecond=0).isoformat()
         else:
             result["last_ping"] = None
             result["next_ping"] = None


### PR DESCRIPTION
`datetime.isoformat` returns different date formats whether microseconds part equals 0 or not.

> __datetime.isoformat([sep])__
> Return a string representing the date and time in ISO 8601 format, YYYY-MM-DDTHH:MM:SS.mmmmmm or, if microsecond is 0, YYYY-MM-DDTHH:MM:SS

ref: https://docs.python.org/2/library/datetime.html#datetime.datetime.isoformat

`datetime.isoformat` function is used in the API and thus producing inconsistency in the API.
[Tests assume the microseconds equals 0](https://github.com/healthchecks/healthchecks/blob/20b046cba717790aa1f55de4a60a83eedafa57ce/hc/api/tests/test_list_checks.py#L15) so let's skip microseconds part from the API as well
