### PR TITLE
Adding Content-Type header to Webhook integrations

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -322,6 +322,12 @@ class Channel(models.Model):
         return parts[2] if len(parts) > 2 else ""
 
     @property
+    def content_type(self):
+        assert self.kind == "webhook"
+        parts = self.value.split("\n")
+        return parts[3] if len(parts) > 3 else ""
+
+    @property
     def slack_team(self):
         assert self.kind == "slack"
         if not self.value.startswith("{"):

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -304,28 +304,44 @@ class Channel(models.Model):
         return user_key, prio, PO_PRIORITIES[prio]
 
     @property
-    def value_down(self):
+    def url_down(self):
         assert self.kind == "webhook"
-        parts = self.value.split("\n")
-        return parts[0]
+        if not self.value.startswith("{"):
+            parts = self.value.split("\n")
+            return parts[0]
+
+        doc = json.loads(self.value)
+        return doc["url_down"]
+        
 
     @property
-    def value_up(self):
+    def url_up(self):
         assert self.kind == "webhook"
-        parts = self.value.split("\n")
-        return parts[1] if len(parts) > 1 else ""
+        if not self.value.startswith("{"):
+            parts = self.value.split("\n")
+            return parts[1] if len(parts) > 1 else ""
+
+        doc = json.loads(self.value)
+        return doc["url_up"]
 
     @property
     def post_data(self):
         assert self.kind == "webhook"
-        parts = self.value.split("\n")
-        return parts[2] if len(parts) > 2 else ""
+        if not self.value.startswith("{"):
+            parts = self.value.split("\n")
+            return parts[2] if len(parts) > 2 else ""
+
+        doc = json.loads(self.value)
+        return doc["post_data"]
 
     @property
-    def content_type(self):
+    def headers(self):
         assert self.kind == "webhook"
-        parts = self.value.split("\n")
-        return parts[3] if len(parts) > 3 else ""
+        if not self.value.startswith("{"):
+            return ""
+
+        doc = json.loads(self.value)
+        return doc["headers"]
 
     @property
     def slack_team(self):

--- a/hc/api/tests/test_notify.py
+++ b/hc/api/tests/test_notify.py
@@ -458,4 +458,4 @@ class NotifyTestCase(BaseTestCase):
     def test_transport_notify(self):
         self._setup_data("webhook", "http://example")
         with self.assertRaises(NotImplementedError):
-            Transport.notify(self.channel, self.check)
+            Transport(self.channel).notify(self.check)

--- a/hc/api/tests/test_notify.py
+++ b/hc/api/tests/test_notify.py
@@ -174,8 +174,8 @@ class NotifyTestCase(BaseTestCase):
     @patch("hc.api.transports.requests.request")
     def test_webhooks_handle_headers(self, mock_request):
         self._setup_data("webhook", '{"url_down": "http://foo.com", '
-            '"url_up": "", "post_data": "data", "headers": '
-            '"{\\\"Content-Type\\\": \\\"application/json\\\"}"}')
+            '"url_up": "", "post_data": "data", '
+            '"headers": {"Content-Type": "application/json"}}')
         self.channel.notify(self.check)
 
         headers = {

--- a/hc/api/transports.py
+++ b/hc/api/transports.py
@@ -147,27 +147,27 @@ class Webhook(HttpTransport):
         return result
 
     def is_noop(self, check):
-        if check.status == "down" and not self.channel.value_down:
+        if check.status == "down" and not self.channel.url_down:
             return True
 
-        if check.status == "up" and not self.channel.value_up:
+        if check.status == "up" and not self.channel.url_up:
             return True
 
         return False
 
     def notify(self, check):
-        url = self.channel.value_down
+        url = self.channel.url_down
         if check.status == "up":
-            url = self.channel.value_up
+            url = self.channel.url_up
 
         assert url
 
         url = self.prepare(url, check, urlencode=True)
         if self.channel.post_data:
-            headers = {}
-            if self.channel.content_type:
-                headers["Content-Type"] = self.channel.content_type
             payload = self.prepare(self.channel.post_data, check)
+            headers = {}
+            if self.channel.headers:
+                headers = json.loads(self.channel.headers)
             return self.post(url, data=payload.encode("utf-8"), headers=headers)
         else:
             return self.get(url)
@@ -233,7 +233,7 @@ class Pushbullet(HttpTransport):
         url = "https://api.pushbullet.com/v2/pushes"
         headers = {
             "Access-Token": self.channel.value,
-            "Content-Type": "application/json"
+            "Conent-Type": "application/json"
         }
         payload = {
             "type": "note",

--- a/hc/api/transports.py
+++ b/hc/api/transports.py
@@ -164,8 +164,11 @@ class Webhook(HttpTransport):
 
         url = self.prepare(url, check, urlencode=True)
         if self.channel.post_data:
+            headers = {}
+            if self.channel.content_type:
+                headers["Content-Type"] = self.channel.content_type
             payload = self.prepare(self.channel.post_data, check)
-            return self.post(url, data=payload.encode("utf-8"))
+            return self.post(url, data=payload.encode("utf-8"), headers=headers)
         else:
             return self.get(url)
 
@@ -230,7 +233,7 @@ class Pushbullet(HttpTransport):
         url = "https://api.pushbullet.com/v2/pushes"
         headers = {
             "Access-Token": self.channel.value,
-            "Conent-Type": "application/json"
+            "Content-Type": "application/json"
         }
         payload = {
             "type": "note",

--- a/hc/api/transports.py
+++ b/hc/api/transports.py
@@ -167,7 +167,7 @@ class Webhook(HttpTransport):
             payload = self.prepare(self.channel.post_data, check)
             headers = {}
             if self.channel.headers:
-                headers = json.loads(self.channel.headers)
+                headers = self.channel.headers
             return self.post(url, data=payload.encode("utf-8"), headers=headers)
         else:
             return self.get(url)

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -69,7 +69,7 @@ class AddWebhookForm(forms.Form):
     headers = forms.CharField(max_length=1000, required=False)
 
     def get_value(self):
-        return json.dumps(self.cleaned_data)
+        return json.dumps(self.cleaned_data, sort_keys=True)
 
 
 phone_validator = RegexValidator(regex='^\+\d{5,15}$',

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta as td
 
 from django import forms
@@ -57,19 +58,18 @@ class AddUrlForm(forms.Form):
 class AddWebhookForm(forms.Form):
     error_css_class = "has-error"
 
-    value_down = forms.URLField(max_length=1000, required=False,
+    url_down = forms.URLField(max_length=1000, required=False,
                                 validators=[WebhookValidator()])
 
-    value_up = forms.URLField(max_length=1000, required=False,
+    url_up = forms.URLField(max_length=1000, required=False,
                               validators=[WebhookValidator()])
 
     post_data = forms.CharField(max_length=1000, required=False)
 
-    content_type = forms.CharField(max_length=1000, required=False)
+    headers = forms.CharField(max_length=1000, required=False)
 
     def get_value(self):
-        d = self.cleaned_data
-        return "\n".join((d["value_down"], d["value_up"], d["post_data"], d["content_type"]))
+        return json.dumps(self.cleaned_data)
 
 
 phone_validator = RegexValidator(regex='^\+\d{5,15}$',

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -65,9 +65,11 @@ class AddWebhookForm(forms.Form):
 
     post_data = forms.CharField(max_length=1000, required=False)
 
+    content_type = forms.CharField(max_length=1000, required=False)
+
     def get_value(self):
         d = self.cleaned_data
-        return "\n".join((d["value_down"], d["value_up"], d["post_data"]))
+        return "\n".join((d["value_down"], d["value_up"], d["post_data"], d["content_type"]))
 
 
 phone_validator = RegexValidator(regex='^\+\d{5,15}$',

--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -66,10 +66,22 @@ class AddWebhookForm(forms.Form):
 
     post_data = forms.CharField(max_length=1000, required=False)
 
-    headers = forms.CharField(max_length=1000, required=False)
+    def __init__(self, *args, **kwargs):
+        self.headers = {}
+        if all(k in kwargs for k in ("header_keys", "header_values")):
+            header_keys = kwargs.pop("header_keys")
+            header_values = kwargs.pop("header_values")
+
+            for i, (key, val) in enumerate(zip(header_keys, header_values)):
+                if key:
+                    self.headers[key] = val
+
+        super(AddWebhookForm, self).__init__(*args, **kwargs)
 
     def get_value(self):
-        return json.dumps(self.cleaned_data, sort_keys=True)
+        val = dict(self.cleaned_data)
+        val["headers"] = self.headers
+        return json.dumps(val, sort_keys=True)
 
 
 phone_validator = RegexValidator(regex='^\+\d{5,15}$',

--- a/hc/front/tests/test_add_webhook.py
+++ b/hc/front/tests/test_add_webhook.py
@@ -18,7 +18,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"url_down": "http://foo.com", "url_up": "https://bar.com", "post_data": "", "headers": ""}')
+        self.assertEqual(c.value, '{"headers": "", "post_data": "", "url_down": "http://foo.com", "url_up": "https://bar.com"}')
 
     def test_it_adds_webhook_using_team_access(self):
         form = {"url_down": "http://foo.com", "url_up": "https://bar.com"}
@@ -30,7 +30,7 @@ class AddWebhookTestCase(BaseTestCase):
 
         c = Channel.objects.get()
         self.assertEqual(c.user, self.alice)
-        self.assertEqual(c.value, '{"url_down": "http://foo.com", "url_up": "https://bar.com", "post_data": "", "headers": ""}')
+        self.assertEqual(c.value, '{"headers": "", "post_data": "", "url_down": "http://foo.com", "url_up": "https://bar.com"}')
 
     def test_it_rejects_bad_urls(self):
         urls = [
@@ -59,7 +59,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.client.post(self.url, form)
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"url_down": "", "url_up": "http://foo.com", "post_data": "", "headers": ""}')
+        self.assertEqual(c.value, '{"headers": "", "post_data": "", "url_down": "", "url_up": "http://foo.com"}')
 
     def test_it_adds_post_data(self):
         form = {"url_down": "http://foo.com", "post_data": "hello"}
@@ -69,7 +69,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"url_down": "http://foo.com", "url_up": "", "post_data": "hello", "headers": ""}')
+        self.assertEqual(c.value, '{"headers": "", "post_data": "hello", "url_down": "http://foo.com", "url_up": ""}')
 
     def test_it_adds_headers(self):
         form = {"url_down": "http://foo.com", "headers": '{"test": "123"}'}
@@ -79,5 +79,5 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"url_down": "http://foo.com", "url_up": "", "post_data": "", "headers": "{\\\"test\\\": \\\"123\\\"}"}')
+        self.assertEqual(c.value, '{"headers": "{\\\"test\\\": \\\"123\\\"}", "post_data": "", "url_down": "http://foo.com", "url_up": ""}')
 

--- a/hc/front/tests/test_add_webhook.py
+++ b/hc/front/tests/test_add_webhook.py
@@ -18,7 +18,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, "http://foo.com\nhttps://bar.com\n")
+        self.assertEqual(c.value, "http://foo.com\nhttps://bar.com\n\n")
 
     def test_it_adds_webhook_using_team_access(self):
         form = {"value_down": "http://foo.com", "value_up": "https://bar.com"}
@@ -30,7 +30,7 @@ class AddWebhookTestCase(BaseTestCase):
 
         c = Channel.objects.get()
         self.assertEqual(c.user, self.alice)
-        self.assertEqual(c.value, "http://foo.com\nhttps://bar.com\n")
+        self.assertEqual(c.value, "http://foo.com\nhttps://bar.com\n\n")
 
     def test_it_rejects_bad_urls(self):
         urls = [
@@ -59,7 +59,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.client.post(self.url, form)
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, "\nhttp://foo.com\n")
+        self.assertEqual(c.value, "\nhttp://foo.com\n\n")
 
     def test_it_adds_post_data(self):
         form = {"value_down": "http://foo.com", "post_data": "hello"}
@@ -69,4 +69,14 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, "http://foo.com\n\nhello")
+        self.assertEqual(c.value, "http://foo.com\n\nhello\n")
+
+    def test_it_adds_content_type(self):
+        form = {"value_down": "http://foo.com", "post_data": "hello", "content_type": "application/json"}
+
+        self.client.login(username="alice@example.org", password="password")
+        r = self.client.post(self.url, form)
+        self.assertRedirects(r, "/integrations/")
+
+        c = Channel.objects.get()
+        self.assertEqual(c.value, "http://foo.com\n\nhello\napplication/json")

--- a/hc/front/tests/test_add_webhook.py
+++ b/hc/front/tests/test_add_webhook.py
@@ -18,7 +18,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"headers": "", "post_data": "", "url_down": "http://foo.com", "url_up": "https://bar.com"}')
+        self.assertEqual(c.value, '{"headers": {}, "post_data": "", "url_down": "http://foo.com", "url_up": "https://bar.com"}')
 
     def test_it_adds_webhook_using_team_access(self):
         form = {"url_down": "http://foo.com", "url_up": "https://bar.com"}
@@ -30,7 +30,7 @@ class AddWebhookTestCase(BaseTestCase):
 
         c = Channel.objects.get()
         self.assertEqual(c.user, self.alice)
-        self.assertEqual(c.value, '{"headers": "", "post_data": "", "url_down": "http://foo.com", "url_up": "https://bar.com"}')
+        self.assertEqual(c.value, '{"headers": {}, "post_data": "", "url_down": "http://foo.com", "url_up": "https://bar.com"}')
 
     def test_it_rejects_bad_urls(self):
         urls = [
@@ -59,7 +59,7 @@ class AddWebhookTestCase(BaseTestCase):
         self.client.post(self.url, form)
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"headers": "", "post_data": "", "url_down": "", "url_up": "http://foo.com"}')
+        self.assertEqual(c.value, '{"headers": {}, "post_data": "", "url_down": "", "url_up": "http://foo.com"}')
 
     def test_it_adds_post_data(self):
         form = {"url_down": "http://foo.com", "post_data": "hello"}
@@ -69,15 +69,15 @@ class AddWebhookTestCase(BaseTestCase):
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"headers": "", "post_data": "hello", "url_down": "http://foo.com", "url_up": ""}')
+        self.assertEqual(c.value, '{"headers": {}, "post_data": "hello", "url_down": "http://foo.com", "url_up": ""}')
 
     def test_it_adds_headers(self):
-        form = {"url_down": "http://foo.com", "headers": '{"test": "123"}'}
+        form = {"url_down": "http://foo.com", "header_key[]": ["test", "test2"], "header_value[]": ["123", "abc"]}
 
         self.client.login(username="alice@example.org", password="password")
         r = self.client.post(self.url, form)
         self.assertRedirects(r, "/integrations/")
 
         c = Channel.objects.get()
-        self.assertEqual(c.value, '{"headers": "{\\\"test\\\": \\\"123\\\"}", "post_data": "", "url_down": "http://foo.com", "url_up": ""}')
+        self.assertEqual(c.value, '{"headers": {"test": "123", "test2": "abc"}, "post_data": "", "url_down": "http://foo.com", "url_up": ""}')
 

--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -437,7 +437,10 @@ def add_email(request):
 @login_required
 def add_webhook(request):
     if request.method == "POST":
-        form = AddWebhookForm(request.POST)
+        header_keys = request.POST.getlist('header_key[]')
+        header_values = request.POST.getlist('header_value[]')
+        form = AddWebhookForm(request.POST or None, 
+            header_keys=header_keys, header_values=header_values)
         if form.is_valid():
             channel = Channel(user=request.team.user, kind="webhook")
             channel.value = form.get_value()

--- a/static/js/webhook.js
+++ b/static/js/webhook.js
@@ -1,4 +1,7 @@
 $(function() {
+    $(".webhook_header_btn:first").addClass("btn-info").text("+")
+    $(".webhook_header_btn:not(:first)").addClass("btn-danger").text("X")
+
     $("#webhook_headers").on("click", ".webhook_header_btn.btn-danger", function(e) {
         e.preventDefault();
         $(this).closest("div.row").remove();

--- a/static/js/webhook.js
+++ b/static/js/webhook.js
@@ -1,0 +1,26 @@
+$(function() {
+    $("#webhook_headers").on("click", ".webhook_header_btn.btn-danger", function(e) {
+        e.preventDefault();
+        $(this).closest("div.row").remove();
+    });
+
+    $("#webhook_headers").on("click", ".webhook_header_btn.btn-info", function(e) {
+        e.preventDefault();
+
+        // Add new header form
+        $("#webhook_headers").append(
+'<div class="row">\
+    <div class="col-xs-6 col-sm-6" style="padding-right: 0px;">\
+        <input type="text" class="form-control" name="header_key[]" placeholder="Key">\
+    </div>\
+    <div class="col-xs-6 col-sm-6" style="padding-left: 0px;">\
+        <div class="input-group">\
+            <input type="text" class="form-control" name="header_value[]" placeholder="Value">\
+            <span class="input-group-btn">\
+                <button class="webhook_header_btn btn btn-danger" type="button" class="btn">X</button>\
+            </span>\
+        </div>\
+    </div>\
+</div>');
+    });
+});

--- a/templates/front/channels.html
+++ b/templates/front/channels.html
@@ -62,16 +62,16 @@
                     {% endif %}
                 {% elif ch.kind == "webhook" %}
                     <table>
-                        {% if ch.value_down %}
+                        {% if ch.url_down %}
                         <tr>
                             <td class="preposition">down&nbsp;</td>
-                            <td>{{ ch.value_down }}</td>
+                            <td>{{ ch.url_down }}</td>
                         </tr>
                         {% endif %}
-                        {% if ch.value_up %}
+                        {% if ch.url_up %}
                         <tr>
                             <td class="preposition">up&nbsp;</td>
-                            <td>{{ ch.value_up }}</td>
+                            <td>{{ ch.url_up }}</td>
                         </tr>
                         {% endif %}
                         {% if ch.post_data %}
@@ -80,10 +80,10 @@
                             <td>{{ ch.post_data }}</td>
                         </tr>
                         {% endif %}
-                        {% if ch.content_type %}
+                        {% if ch.headers %}
                         <tr>
-                            <td class="preposition">type&nbsp;</td>
-                            <td>{{ ch.content_type }}</td>
+                            <td class="preposition">headers&nbsp;</td>
+                            <td>{{ ch.headers }}</td>
                         </tr>
                         {% endif %}
                     </table>

--- a/templates/front/channels.html
+++ b/templates/front/channels.html
@@ -80,6 +80,12 @@
                             <td>{{ ch.post_data }}</td>
                         </tr>
                         {% endif %}
+                        {% if ch.content_type %}
+                        <tr>
+                            <td class="preposition">type&nbsp;</td>
+                            <td>{{ ch.content_type }}</td>
+                        </tr>
+                        {% endif %}
                     </table>
                 {% elif ch.kind == "pushbullet" %}
                     <span class="preposition">API key</span>

--- a/templates/front/log.html
+++ b/templates/front/log.html
@@ -96,7 +96,7 @@
                 {% elif event.channel.kind == "po" %}
                     Sent a Pushover notification
                 {% elif event.channel.kind == "webhook" %}
-                    Called webhook {{ event.channel.value_down }}
+                    Called webhook {{ event.channel.url_down }}
                 {% else %}
                     Sent alert to {{ event.channel.kind|capfirst }}
                 {% endif %}

--- a/templates/integrations/add_webhook.html
+++ b/templates/integrations/add_webhook.html
@@ -105,6 +105,22 @@
                 {% endif %}
             </div>
         </div>
+        <div class="form-group {{ form.content_type.css_classes }}">
+            <label class="col-sm-2 control-label">Content-Type</label>
+            <div class="col-sm-10">
+                <input
+                    type="text"
+                    class="form-control"
+                    name="content_type"
+                    placeholder='application/json'
+                    value="{{ form.content_type.value|default:"" }}">
+                {% if form.content_type.errors %}
+                <div class="help-block">
+                    {{ form.content_type.errors|join:"" }}
+                </div>
+                {% endif %}
+            </div>
+        </div>
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <button type="submit" class="btn btn-primary">Save Integration</button>

--- a/templates/integrations/add_webhook.html
+++ b/templates/integrations/add_webhook.html
@@ -57,34 +57,34 @@
     <form method="post" class="form-horizontal">
         {% csrf_token %}
         <input type="hidden" name="kind" value="webhook" />
-        <div class="form-group {{ form.value_down.css_classes }}">
+        <div class="form-group {{ form.url_down.css_classes }}">
             <label class="col-sm-2 control-label">URL for "down" events</label>
             <div class="col-sm-10">
                 <input
                     type="text"
                     class="form-control"
-                    name="value_down"
+                    name="url_down"
                     placeholder="http://..."
-                    value="{{ form.value_down.value|default:"" }}">
-                {% if form.value_down.errors %}
+                    value="{{ form.url_down.value|default:"" }}">
+                {% if form.url_down.errors %}
                 <div class="help-block">
-                    {{ form.value_down.errors|join:"" }}
+                    {{ form.url_down.errors|join:"" }}
                 </div>
                 {% endif %}
             </div>
         </div>
-        <div class="form-group {{ form.value_up.css_classes }}">
+        <div class="form-group {{ form.url_up.css_classes }}">
             <label class="col-sm-2 control-label">URL for "up" events</label>
             <div class="col-sm-10">
                 <input
                     type="text"
                     class="form-control"
-                    name="value_up"
+                    name="url_up"
                     placeholder="http://..."
-                    value="{{ form.value_up.value|default:"" }}">
-                {% if form.value_up.errors %}
+                    value="{{ form.url_up.value|default:"" }}">
+                {% if form.url_up.errors %}
                 <div class="help-block">
-                    {{ form.value_up.errors|join:"" }}
+                    {{ form.url_up.errors|join:"" }}
                 </div>
                 {% endif %}
             </div>
@@ -105,18 +105,18 @@
                 {% endif %}
             </div>
         </div>
-        <div class="form-group {{ form.content_type.css_classes }}">
-            <label class="col-sm-2 control-label">Content-Type</label>
+        <div class="form-group {{ form.headers.css_classes }}">
+            <label class="col-sm-2 control-label">Custom Headers</label>
             <div class="col-sm-10">
                 <input
                     type="text"
                     class="form-control"
-                    name="content_type"
-                    placeholder='application/json'
-                    value="{{ form.content_type.value|default:"" }}">
-                {% if form.content_type.errors %}
+                    name="headers"
+                    placeholder='{"Content-Type": "application/json"}'
+                    value="{{ form.headers.value|default:"" }}">
+                {% if form.headers.errors %}
                 <div class="help-block">
-                    {{ form.content_type.errors|join:"" }}
+                    {{ form.headers.errors|join:"" }}
                 </div>
                 {% endif %}
             </div>

--- a/templates/integrations/add_webhook.html
+++ b/templates/integrations/add_webhook.html
@@ -108,6 +108,23 @@
         <div class="form-group {{ form.headers.css_classes }}">
             <label class="col-sm-2 control-label">Headers</label>
             <div id="webhook_headers" class="col-xs-12 col-sm-10">
+                {% if form.headers %}
+                {% for k,v in form.headers.items %}
+                <div class="row">
+                    <div class="col-xs-6 col-sm-6" style="padding-right: 0px;">
+                        <input type="text" class="form-control" name="header_key[]" placeholder="Key" value="{{ k|default:"" }}">
+                    </div>
+                    <div class="col-xs-6 col-sm-6" style="padding-left: 0px;">
+                        <div class="input-group">
+                            <input type="text" class="form-control" name="header_value[]" placeholder="Value" value="{{ v|default:"" }}">
+                            <span class="input-group-btn">
+                                <button class="webhook_header_btn btn" type="button" class="btn"></button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+                {% else %}
                 <div class="row">
                     <div class="col-xs-6 col-sm-6" style="padding-right: 0px;">
                         <input type="text" class="form-control" name="header_key[]" placeholder="Key">
@@ -121,13 +138,8 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
             </div>
-            <input type="hidden"
-                    type="text"
-                    class="form-control"
-                    name="headers"
-                    value="{{ form.headers.value|default:"" }}">
-            
         </div>
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">

--- a/templates/integrations/add_webhook.html
+++ b/templates/integrations/add_webhook.html
@@ -106,20 +106,28 @@
             </div>
         </div>
         <div class="form-group {{ form.headers.css_classes }}">
-            <label class="col-sm-2 control-label">Custom Headers</label>
-            <div class="col-sm-10">
-                <input
+            <label class="col-sm-2 control-label">Headers</label>
+            <div id="webhook_headers" class="col-xs-12 col-sm-10">
+                <div class="row">
+                    <div class="col-xs-6 col-sm-6" style="padding-right: 0px;">
+                        <input type="text" class="form-control" name="header_key[]" placeholder="Key">
+                    </div>
+                    <div class="col-xs-6 col-sm-6" style="padding-left: 0px;">
+                        <div class="input-group">
+                            <input type="text" class="form-control" name="header_value[]" placeholder="Value">
+                            <span class="input-group-btn">
+                                <button class="webhook_header_btn btn btn-info" type="button" class="btn">+</button>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <input type="hidden"
                     type="text"
                     class="form-control"
                     name="headers"
-                    placeholder='{"Content-Type": "application/json"}'
                     value="{{ form.headers.value|default:"" }}">
-                {% if form.headers.errors %}
-                <div class="help-block">
-                    {{ form.headers.errors|join:"" }}
-                </div>
-                {% endif %}
-            </div>
+            
         </div>
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
@@ -129,4 +137,12 @@
     </form>
 </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+{% compress js %}
+<script src="{% static 'js/jquery-2.1.4.min.js' %}"></script>
+<script src="{% static 'js/bootstrap.min.js' %}"></script>
+<script src="{% static 'js/webhook.js' %}"></script>
+{% endcompress %}
 {% endblock %}


### PR DESCRIPTION
Adding Content-Type header to Webhook integrations to work correctly with services like [IFTTT Maker Webhooks](https://ifttt.com/maker_webhooks) which require a specific content type, like application/json.

If the content-type is not provided, the post data is not parsed by IFTTT, which prevents the ability to use variables like, `$NAME` and `$STATUS`