### PR TITLE
Added deterministic handling of sqlite database location

### DIFF
--- a/hc/settings.py
+++ b/hc/settings.py
@@ -84,7 +84,7 @@ TEST_RUNNER = 'hc.api.tests.CustomRunner'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': './hc.sqlite',
+        'NAME': '{0}/hc.sqlite'.format(BASE_DIR),
     }
 }
 


### PR DESCRIPTION
When running the migration command from outside of the application directory the sqlite database is created in the current working directory at the time of the command being executed. This commit updates the file path to be relative to the location of the settings file.