### PR TITLE
Setting api key will save it as a byte

### DIFF
--- a/hc/accounts/models.py
+++ b/hc/accounts/models.py
@@ -118,7 +118,7 @@ class Profile(models.Model):
         emails.change_email(self.user.email, ctx)
 
     def set_api_key(self):
-        self.api_key = urlsafe_b64encode(os.urandom(24))
+        self.api_key = urlsafe_b64encode(os.urandom(24)).decode()
         self.save()
 
     def checks_from_all_teams(self):


### PR DESCRIPTION
urlsafe_b64encode return a byte, which will result in an api key saved with something like b'apikey'
I did not tested it but [urlsafe_b64decode](https://docs.python.org/3/library/base64.html#base64.urlsafe_b64decode) looks like doing the job also.