### PR TITLE
Fix for Python 3.6

### DIFF
--- a/hc/api/management/commands/smtpd.py
+++ b/hc/api/management/commands/smtpd.py
@@ -13,7 +13,7 @@ class Listener(SMTPServer):
         self.stdout = stdout
         super(Listener, self).__init__(localaddr, None)
 
-    def process_message(self, peer, mailfrom, rcpttos, data):
+    def process_message(self, peer, mailfrom, rcpttos, data, mail_options=None, rcpt_options=None):
         to_parts = rcpttos[0].split("@")
         code = to_parts[0]
 


### PR DESCRIPTION
smtpd doesn't work with python3.6

Note, I haven't tested this with python 3.5 yet. Let me know if you're interested in merging and I will test.