### PR TITLE
update Readme with pip install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ The building blocks are:
 These are instructions for setting up healthchecks Django app
 in development environment.
 
+* install dependencies (Debian/Ubuntu)
+
+        $ sudo apt-get update
+        $ sudo apt-get install -y gcc python3-dev
+
 * prepare directory for project code and virtualenv:
 
         $ mkdir -p ~/webapps


### PR DESCRIPTION
pip install will fail when you cannot compile some of the dependencies.
one is gcc the other is the Python.h

```
Building wheels for collected packages: rcssmin, rjsmin
  Running setup.py bdist_wheel for rcssmin ... error
  Complete output from command /home/ubuntu/webapps/hc-venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-ipfho29k/rcssmin/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-u0q6mggl --python-tag cp36:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  copying ./rcssmin.py -> build/lib.linux-x86_64-3.6
  running build_ext
  building '_rcssmin' extension
  creating build/temp.linux-x86_64-3.6
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DEXT_MODULE=_rcssmin -UEXT_PACKAGE -I_setup/include -I/usr/include/python3.6m -I/home/ubuntu/webapps/hc-venv/include/python3.6m -c rcssmin.c -o build/temp.linux-x86_64-3.6/rcssmin.o
  unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for rcssmin
  Running setup.py clean for rcssmin
  Running setup.py bdist_wheel for rjsmin ... error
  Complete output from command /home/ubuntu/webapps/hc-venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-ipfho29k/rjsmin/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-axnaq3w9 --python-tag cp36:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  copying ./rjsmin.py -> build/lib.linux-x86_64-3.6
  running build_ext
  building '_rjsmin' extension
  creating build/temp.linux-x86_64-3.6
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DEXT_MODULE=_rjsmin -UEXT_PACKAGE -I_setup/include -I/usr/include/python3.6m -I/home/ubuntu/webapps/hc-venv/include/python3.6m -c rjsmin.c -o build/temp.linux-x86_64-3.6/rjsmin.o
  unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

```
  Running setup.py bdist_wheel for rjsmin ... error
  Complete output from command /home/ubuntu/webapps/hc-venv/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-cfntw7bo/rjsmin/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-ytqxu9_b --python-tag cp36:
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  copying ./rjsmin.py -> build/lib.linux-x86_64-3.6
  running build_ext
  building '_rjsmin' extension
  creating build/temp.linux-x86_64-3.6
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DEXT_MODULE=_rjsmin -UEXT_PACKAGE -I_setup/include -I/usr/include/python3.6m -I/home/ubuntu/webapps/hc-venv/include/python3.6m -c rjsmin.c -o build/temp.linux-x86_64-3.6/rjsmin.o
  In file included from rjsmin.c:18:0:
  _setup/include/cext.h:34:10: fatal error: Python.h: No such file or directory
   #include "Python.h"
            ^~~~~~~~~~
  compilation terminated.
```