### PR TITLE
fix api docs to point to project settings instead of account settings

### DIFF
--- a/templates/front/docs_api.html
+++ b/templates/front/docs_api.html
@@ -59,8 +59,8 @@
 API key. By default, an user account on {% site_name %} doesn't have
 an API key. You can create one in the
 {% if request.user.is_authenticated %}
-<a href="{% url 'hc-profile' %}">Account Settings</a>
-{% else %}<b>Account Settings</b>{% endif %} page.
+<a href="{% url 'hc-project-settings' %}">Project Settings</a>
+{% else %}<b>Project Settings</b>{% endif %} page.
 </p>
 
 <p>The client can authenticate itself by sending an appropriate HTTP


### PR DESCRIPTION
For a while I thought I had to pay in order to get the API key. Turns out it was just in the project settings page instead. 

You should consider adding a row in the pricing page to indicate that api access is included in the free tier as well. 

Thanks for creating such a great product! Go HC!