### PR TITLE
Update croniter to 0.3.29

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-croniter==0.3.26
+croniter==0.3.29
 Django==2.1.7
 django_compressor==2.2
 psycopg2==2.7.5


### PR DESCRIPTION
## Background

```
Collecting croniter==0.3.26 (from -r requirements.txt (line 1))
  Could not find a version that satisfies the requirement croniter==0.3.26 (from -r requirements.txt (line 1)) (from versions: 0.1.4.macosx-10.5-i386, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.2.0, 0.2.2, 0.2.4, 0.2.5, 0.2.7, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.3.9, 0.3.10, 0.3.11, 0.3.12, 0.3.13, 0.3.14, 0.3.15, 0.3.16, 0.3.17, 0.3.18, 0.3.19, 0.3.20, 0.3.22, 0.3.23, 0.3.24, 0.3.25, 0.3.28, 0.3.29)
No matching distribution found for croniter==0.3.26 (from -r requirements.txt (line 1))
```

croniter 0.3.26 has been deleted since croniter had a history stripping.

please refer to https://pypi.org/project/croniter/#id1

## Changes

- Update croniter to 0.3.29