### PR TITLE
Increase allowable length of Matrix room alias

### DIFF
--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -173,7 +173,7 @@ class ChannelNameForm(forms.Form):
 
 class AddMatrixForm(forms.Form):
     error_css_class = "has-error"
-    alias = forms.CharField(max_length=40)
+    alias = forms.CharField(max_length=100)
 
     def clean_alias(self):
         v = self.cleaned_data["alias"]


### PR DESCRIPTION
The existing 40 character limit prevents using the integration will Matrix servers that might have a fairly lengthy hostname (ie. 'matrix.internal.example.com' would only allow 12 characters for the
room name or ID, and room IDs are 19 characters long).

Increasing the `max_length` to `100` is still fairly arbitrary but itdoes match up with the `max_length` of the `name` field of the `Channel` model and should cover most instances.