### PR TITLE
Remove redundant '-X POST' to curl

### DIFF
--- a/templates/docs/attaching_logs.html
+++ b/templates/docs/attaching_logs.html
@@ -9,7 +9,7 @@ the captured output to SITE_NAME:</p>
 <div class="highlight"><pre><span></span><code><span class="ch">#!/bin/sh</span>
 
 <span class="nv">m</span><span class="o">=</span><span class="k">$(</span>/usr/bin/certbot renew <span class="m">2</span>&gt;<span class="p">&amp;</span><span class="m">1</span><span class="k">)</span>
-curl -fsS --retry <span class="m">3</span> -X POST --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> PING_URL
+curl -fsS --retry <span class="m">3</span> --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> PING_URL
 </code></pre></div>
 
 
@@ -23,12 +23,12 @@ depending on the exit code:</p>
 <span class="nv">m</span><span class="o">=</span><span class="k">$(</span>/usr/bin/certbot renew <span class="m">2</span>&gt;<span class="p">&amp;</span><span class="m">1</span><span class="k">)</span>
 
 <span class="k">if</span> <span class="o">[</span> <span class="nv">$?</span> -ne <span class="m">0</span> <span class="o">]</span><span class="p">;</span> <span class="k">then</span> <span class="nv">url</span><span class="o">=</span><span class="nv">$url</span>/fail<span class="p">;</span> <span class="k">fi</span>
-curl -fsS --retry <span class="m">3</span> -X POST --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> <span class="nv">$url</span>
+curl -fsS --retry <span class="m">3</span> --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> <span class="nv">$url</span>
 </code></pre></div>
 
 
 <h2>All in One Line</h2>
 <p>Finally, all of the above can be packaged in a single line. The one-line
 version can be put directly in crontab, without using a wrapper script.</p>
-<div class="highlight"><pre><span></span><code><span class="nv">m</span><span class="o">=</span><span class="k">$(</span>/usr/bin/certbot renew <span class="m">2</span>&gt;<span class="p">&amp;</span><span class="m">1</span><span class="k">)</span><span class="p">;</span> curl -fsS -X POST --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> <span class="s2">&quot;PING_URL</span><span class="k">$(</span><span class="o">[</span> <span class="nv">$?</span> -ne <span class="m">0</span> <span class="o">]</span> <span class="o">&amp;&amp;</span> <span class="nb">echo</span> -n /fail<span class="k">)</span><span class="s2">&quot;</span>
+<div class="highlight"><pre><span></span><code><span class="nv">m</span><span class="o">=</span><span class="k">$(</span>/usr/bin/certbot renew <span class="m">2</span>&gt;<span class="p">&amp;</span><span class="m">1</span><span class="k">)</span><span class="p">;</span> curl -fsS --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> <span class="s2">&quot;PING_URL</span><span class="k">$(</span><span class="o">[</span> <span class="nv">$?</span> -ne <span class="m">0</span> <span class="o">]</span> <span class="o">&amp;&amp;</span> <span class="nb">echo</span> -n /fail<span class="k">)</span><span class="s2">&quot;</span>
 </code></pre></div>

--- a/templates/docs/attaching_logs.md
+++ b/templates/docs/attaching_logs.md
@@ -15,7 +15,7 @@ the captured output to SITE_NAME:
 #!/bin/sh
 
 m=$(/usr/bin/certbot renew 2>&1)
-curl -fsS --retry 3 -X POST --data-raw "$m" PING_URL
+curl -fsS --retry 3 --data-raw "$m" PING_URL
 ```
 
 ## In Combination with the `/fail` Endpoint
@@ -31,7 +31,7 @@ url=PING_URL
 m=$(/usr/bin/certbot renew 2>&1)
 
 if [ $? -ne 0 ]; then url=$url/fail; fi
-curl -fsS --retry 3 -X POST --data-raw "$m" $url
+curl -fsS --retry 3 --data-raw "$m" $url
 ```
 
 ## All in One Line
@@ -40,5 +40,5 @@ Finally, all of the above can be packaged in a single line. The one-line
 version can be put directly in crontab, without using a wrapper script.
 
 ```bash
-m=$(/usr/bin/certbot renew 2>&1); curl -fsS -X POST --data-raw "$m" "PING_URL$([ $? -ne 0 ] && echo -n /fail)"
+m=$(/usr/bin/certbot renew 2>&1); curl -fsS --data-raw "$m" "PING_URL$([ $? -ne 0 ] && echo -n /fail)"
 ```

--- a/templates/docs/bash.html
+++ b/templates/docs/bash.html
@@ -40,7 +40,7 @@ will accept and store first 10KB of the request body.</p>
 <div class="highlight"><pre><span></span><code><span class="ch">#!/bin/sh</span>
 
 <span class="nv">m</span><span class="o">=</span><span class="k">$(</span>/usr/bin/certbot renew <span class="m">2</span>&gt;<span class="p">&amp;</span><span class="m">1</span><span class="k">)</span>
-curl -fsS --retry <span class="m">3</span> -X POST --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> PING_URL
+curl -fsS --retry <span class="m">3</span> --data-raw <span class="s2">&quot;</span><span class="nv">$m</span><span class="s2">&quot;</span> PING_URL
 </code></pre></div>
 
 

--- a/templates/docs/bash.md
+++ b/templates/docs/bash.md
@@ -47,7 +47,7 @@ In the below example, certbot's output is captured and submitted via HTTP POST:
 #!/bin/sh
 
 m=$(/usr/bin/certbot renew 2>&1)
-curl -fsS --retry 3 -X POST --data-raw "$m" PING_URL
+curl -fsS --retry 3 --data-raw "$m" PING_URL
 ```
 
 ## Auto-provisioning New Checks


### PR DESCRIPTION
Passing `--data-raw` to curl implies the request is method will be POST.
Unless we intend to do something entirely different, -X method override
shouldn't be used.

Curl's author Daniel Stenberg (@bagder) wrote about this back in 2015
https://daniel.haxx.se/blog/2015/09/11/unnecessary-use-of-curl-x/