### PR TITLE
Add runitor to resources.{md,html}

### DIFF
--- a/templates/docs/resources.html
+++ b/templates/docs/resources.html
@@ -34,4 +34,5 @@ Please submit additions and corrections
 <ul>
 <li><a href="https://github.com/taylus/HealthTray">HealthTray</a> – Watch your healthchecks in Windows system tray.</li>
 <li><a href="https://github.com/healthchecks/dashboard">healthchecks/dashboard</a> – A standalone HTML page showing the status of the checks in your account.</li>
+<li><a href="https://github.com/bdd/runitor">runitor</a> - A command runner with healthchecks.io integration to keep your scripts and containers simple.</li>
 </ul>

--- a/templates/docs/resources.md
+++ b/templates/docs/resources.md
@@ -36,3 +36,4 @@ Please submit additions and corrections
 
 * [HealthTray](https://github.com/taylus/HealthTray) – Watch your healthchecks in Windows system tray.
 * [healthchecks/dashboard](https://github.com/healthchecks/dashboard) – A standalone HTML page showing the status of the checks in your account.
+* [runitor](https://github.com/bdd/runitor) - A command runner with healthchecks.io integration to keep your scripts and containers simple.


### PR DESCRIPTION
From its README:

Why Do I Need This Instead of Calling curl from a Shell Script?

In addition to clean separation of concerns from the thing that needs to
run and the act of calling an external monitor, runitor packs a few neat
extra features that are bit more involved than single line additions to
a script.

It can capture the stdout and stderr of the command to send it along
with execution reports, a.k.a. pings. When you respond to an alert you
can quickly start investigating the issue with the relevant context
already available.

It can be used as a long running process acting as a task scheduler,
executing the command at specified intervals. This feature comes in
handy when you don't readily have access to a job scheduler like crond
or systemd.timer. Works well in one process per container environments.