### PR TITLE
Switched from pipeing to --output /dev/null for curl

### DIFF
--- a/templates/docs/monitoring_cron_jobs.html
+++ b/templates/docs/monitoring_cron_jobs.html
@@ -42,7 +42,7 @@ increasingly important as you add more checks to your account.</p>
 after the command:</p>
 <div class="highlight"><pre><span></span><code>$ crontab -e
 <span class="c1"># m h dom mon dow command</span>
-  <span class="m">8</span> <span class="m">6</span> * * * /home/user/backup.sh <span class="o">&amp;&amp;</span> curl -fsS --retry <span class="m">3</span> PING_URL &gt; /dev/null
+  <span class="m">8</span> <span class="m">6</span> * * * /home/user/backup.sh <span class="o">&amp;&amp;</span> curl -fsS --retry <span class="m">3</span> --output /dev/null PING_URL
 </code></pre></div>
 
 

--- a/templates/docs/monitoring_cron_jobs.md
+++ b/templates/docs/monitoring_cron_jobs.md
@@ -41,7 +41,7 @@ after the command:
 ```bash
 $ crontab -e
 # m h dom mon dow command
-  8 6 * * * /home/user/backup.sh && curl -fsS --retry 3 PING_URL > /dev/null
+  8 6 * * * /home/user/backup.sh && curl -fsS --retry 3 --output /dev/null PING_URL
 ```
 
 Now, each time your cron job runs, it will send a HTTP request to the ping URL.

--- a/templates/front/snippets/crontab.html
+++ b/templates/front/snippets/crontab.html
@@ -1,3 +1,3 @@
 <div class="highlight"><pre><span></span><span class="c1"># m h dom mon dow command</span>
-  <span class="m">8</span> <span class="m">6</span> *   *   *   /home/user/backup.sh <span class="o">&amp;&amp;</span> curl -fsS --retry <span class="m">3</span> {{ ping_url }} &gt; /dev/null
+  <span class="m">8</span> <span class="m">6</span> *   *   *   /home/user/backup.sh <span class="o">&amp;&amp;</span> curl -fsS --retry <span class="m">3</span> --output /dev/null {{ ping_url }}
 </pre></div>

--- a/templates/front/snippets/crontab.txt
+++ b/templates/front/snippets/crontab.txt
@@ -1,2 +1,2 @@
 # m h dom mon dow command
-  8 6 *   *   *   /home/user/backup.sh && curl -fsS --retry 3 PING_URL > /dev/null
+  8 6 *   *   *   /home/user/backup.sh && curl -fsS --retry 3 --output /dev/null PING_URL


### PR DESCRIPTION
- That way the user could still receive logs e.g. by using the traditional `MAILTO` attribute of cron.
- Maybe the system would deliver the outputs over the default notification-system - the usage of the pipe operator breaks this for every command in the chain.