### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Dependencies
+
+On Debian:
+
+```
+sudo apt install libpq-dev
+pip3 install -r requirements.txt
+pip3 install markdown django
+```
+
+## Adding Documentation
+
+1. Create the appropriate markdown page under `templates/docs`
+2. Add the page to `/templates/front/base_docs.html`
+3. Generate the HTML assets with `python3 manage.py render_docs` - note that the `manage.py` is in the root of the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,23 @@
 # Contributing
 
-## Dependencies
+I'm open to feature suggestions and happy to review code contributions.
+If you are planning to contribute something larger than a small, straightforward
+bugfix, please open an issue so we can discuss it first. Otherwise you are risking a 
+"no" or a "yes, but let's do it differently" to an already implemented feature.
 
-On Debian:
+## Code Style
 
-```
-sudo apt install libpq-dev
-pip3 install -r requirements.txt
-pip3 install markdown django
-```
+* Format your Python code with [black](https://black.readthedocs.io/en/stable/).
+* Prefer simplicity over cleverness.
+* If you are fixing a bug or adding a feature, add a test. Run tests before 
+  submitting pull requests.
 
 ## Adding Documentation
 
-1. Create the appropriate markdown page under `templates/docs`
-2. Add the page to `/templates/front/base_docs.html`
-3. Generate the HTML assets with `python3 manage.py render_docs` - note that the `manage.py` is in the root of the project.
+This project uses the Markdown format for documentation. Use the `render_docs` 
+management command to generate the HTML version of the documentation. To add a new
+documentation page:
+
+1. Create the appropriate .md file under `templates/docs`
+2. Generate the HTML version with `./manage.py render_docs` 
+3. Add the page to the navigation in `/templates/front/base_docs.html`


### PR DESCRIPTION
There are no docs on how to contribute to this repo. Adding a few pointers for others to use in the future.

- Add requirements for debian hosts
- Add section that explains how to add new docs.


Note: this could also be moved to the docs/templates folder, with a separate CONTRIBUTING.md at the root level that explains how to install and run this project.