### PR TITLE
Modify format of service name in Teams notification

### DIFF
--- a/templates/integrations/msteams_message.json
+++ b/templates/integrations/msteams_message.json
@@ -3,7 +3,7 @@
     "@type": "MessageCard",
     "@context": "https://schema.org/extensions",
     "themeColor": "{% if check.status == "up" %}5cb85c{% endif %}{% if check.status == "down" %}d9534f{% endif %}",
-    "text": "“{{ check.name_then_code|escapejs }}” is {{ check.status|upper }}.",
+    "text": "`{{ check.name_then_code|escapejs }}` is {{ check.status|upper }}.",
     "sections": [
         {
             "facts": [


### PR DESCRIPTION
Teams notifications have all text parsed as markdown.  If the service name has underscores in them it causes the service name to be misrendered.

This change puts backquotes around the service name, which formats it as fixed width on a grey background, with underscores handled correctly and pulls your focus to the service name.

An example of what happens currently is attached.

There is a newer notifications message format that is recommended - see https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference - but I'll experiment with that offline