### PR TITLE
Update README.txt to include more dev setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ in development environment.
 * install dependencies (Debian/Ubuntu)
 
         $ sudo apt-get update
-        $ sudo apt-get install -y gcc python3-dev python3-venv
+        $ sudo apt-get install -y gcc python3-dev python3-venv libpq-dev
 
 * prepare directory for project code and virtualenv:
 
@@ -44,6 +44,7 @@ in development environment.
 
         $ python3 -m venv hc-venv
         $ source hc-venv/bin/activate
+        $ pip3 install wheel #make sure wheel is installed in the venv
 
 * check out project code:
 


### PR DESCRIPTION
I wanted to play with customizing the source for my use but had to manually install `libpq-dev` on my Ubuntu 20.04 install and `wheel` in my venv, so I'm adding those steps to the README to make it easier for others.