### PR TITLE
Add http header auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ Healthchecks reads configuration from the following environment variables:
 | PUSHOVER_EMERGENCY_EXPIRATION | `86400`
 | PUSHOVER_EMERGENCY_RETRY_DELAY | `300`
 | PUSHOVER_SUBSCRIPTION_URL | `None`
-| REMOTE_USER_HEADER | `AUTH_USER` | An incoming HTTP header that will be used to identify the user in place of authentication (e.g., for identity-aware proxies). See [the django docs](https://docs.djangoproject.com/en/3.1/howto/auth-remote-user/) for more details.
-| REMOTE_USER_HEADER_TYPE | `""` | If set to `EMAIL`, the application will log users in by the email present in the specified header. If set to `ID`, it will treat the header as their UUID. If unset or set to any other value, header-based authentication will be disabled.
+| REMOTE_USER_HEADER | `AUTH_USER` | See [External Authentication](#external-authentication) for details.
+| REMOTE_USER_HEADER_TYPE | `None` | See [External Authentication](#external-authentication) for details.
 | SHELL_ENABLED | `"False"`
 | SLACK_CLIENT_ID | `None`
 | SLACK_CLIENT_SECRET | `None`
@@ -330,6 +330,14 @@ Note that WebAuthn requires HTTPS, even if running on localhost. To test WebAuth
 locally with a self-signed certificate, you can use the `runsslserver` command
 from the `django-sslserver` package.
 
+## External Authentication
+
+HealthChecks supports external authentication by means of HTTP headers set by reverse proxies or the WSGI server. This allows you to integrate it into your existing authentication system (e.g., LDAP or OAuth) via an authenticating proxy. When this option is enabled, *healtchecks will trust the header's value implicitly*, so it is *very important* to ensure that attackers cannot set the value themselves (and thus impersonate any user). How to do this varies by your chosen proxy, but generally involves configuring it to strip out headers that normalize to the same name as the chosen identity header. More information about configuring this can be found in the [Django documentation](https://docs.djangoproject.com/en/3.1/howto/auth-remote-user/).
+
+To enable this feature, set the following environment variables:
+
+1. `REMOTE_USER_HEADER` &mdash; set this to the header you wish to authenticate with. HTTP headers will be prefixed with `HTTP_` and have any dashes converted to underscores. Headers without that prefix can be set by the WSGI server itself only, which is more secure.
+2. `REMOTE_USER_HEADER_TYPE` &mdash; If set to `EMAIL`, the specified header will be treated as the user's email. If set to `ID`, the specified header will be set to the user's UUID. Any other value (including empty, the default) disables header-based authentication.
 
 ## Integrations
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Healthchecks reads configuration from the following environment variables:
 | PUSHOVER_EMERGENCY_EXPIRATION | `86400`
 | PUSHOVER_EMERGENCY_RETRY_DELAY | `300`
 | PUSHOVER_SUBSCRIPTION_URL | `None`
+| REMOTE_USER_HEADER | `AUTH_USER` | An incoming HTTP header that will be used to identify the user in place of authentication (e.g., for identity-aware proxies). See [the django docs](https://docs.djangoproject.com/en/3.1/howto/auth-remote-user/) for more details.
+| REMOTE_USER_HEADER_TYPE | `""` | If set to `EMAIL`, the application will log users in by the email present in the specified header. If set to `ID`, it will treat the header as their UUID. If unset or set to any other value, header-based authentication will be disabled.
 | SHELL_ENABLED | `"False"`
 | SLACK_CLIENT_ID | `None`
 | SLACK_CLIENT_SECRET | `None`

--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ Healthchecks reads configuration from the following environment variables:
 | PUSHOVER_EMERGENCY_EXPIRATION | `86400`
 | PUSHOVER_EMERGENCY_RETRY_DELAY | `300`
 | PUSHOVER_SUBSCRIPTION_URL | `None`
-| REMOTE_USER_HEADER | `AUTH_USER` | See [External Authentication](#external-authentication) for details.
-| REMOTE_USER_HEADER_TYPE | `None` | See [External Authentication](#external-authentication) for details.
+| REMOTE_USER_HEADER | `None` | See [External Authentication](#external-authentication) for details.
 | SHELL_ENABLED | `"False"`
 | SLACK_CLIENT_ID | `None`
 | SLACK_CLIENT_SECRET | `None`
@@ -332,12 +331,25 @@ from the `django-sslserver` package.
 
 ## External Authentication
 
-HealthChecks supports external authentication by means of HTTP headers set by reverse proxies or the WSGI server. This allows you to integrate it into your existing authentication system (e.g., LDAP or OAuth) via an authenticating proxy. When this option is enabled, *healtchecks will trust the header's value implicitly*, so it is *very important* to ensure that attackers cannot set the value themselves (and thus impersonate any user). How to do this varies by your chosen proxy, but generally involves configuring it to strip out headers that normalize to the same name as the chosen identity header. More information about configuring this can be found in the [Django documentation](https://docs.djangoproject.com/en/3.1/howto/auth-remote-user/).
+HealthChecks supports external authentication by means of HTTP headers set by
+reverse proxies or the WSGI server. This allows you to integrate it into your
+existing authentication system (e.g., LDAP or OAuth) via an authenticating proxy.
+When this option is enabled, **healtchecks will trust the header's value implicitly**,
+so it is **very important** to ensure that attackers cannot set the value themselves
+(and thus impersonate any user). How to do this varies by your chosen proxy,
+but generally involves configuring it to strip out headers that normalize to the
+same name as the chosen identity header.
 
-To enable this feature, set the following environment variables:
+To enable this feature, set the `REMOTE_USER_HEADER` value to a header you wish to
+authenticate with. HTTP headers will be prefixed with `HTTP_` and have any dashes
+converted to underscores. Headers without that prefix can be set by the WSGI server
+itself only, which is more secure.
 
-1. `REMOTE_USER_HEADER` &mdash; set this to the header you wish to authenticate with. HTTP headers will be prefixed with `HTTP_` and have any dashes converted to underscores. Headers without that prefix can be set by the WSGI server itself only, which is more secure.
-2. `REMOTE_USER_HEADER_TYPE` &mdash; If set to `EMAIL`, the specified header will be treated as the user's email. If set to `ID`, the specified header will be set to the user's UUID. Any other value (including empty, the default) disables header-based authentication.
+When `REMOTE_USER_HEADER` is set, Healthchecks will:
+ - assume the header contains user's email address
+ - look up and automatically log in the user with a matching email address
+ - automatically create an user account if it does not exist
+ - disable the default authentication methods (login link to email, password)
 
 ## Integrations
 

--- a/hc/accounts/backends.py
+++ b/hc/accounts/backends.py
@@ -1,5 +1,8 @@
 from django.contrib.auth.models import User
 from hc.accounts.models import Profile
+from django.contrib.auth.backends import RemoteUserBackend
+from hc.accounts import views
+from django.conf import settings
 
 
 class BasicBackend(object):
@@ -36,3 +39,14 @@ class EmailBackend(BasicBackend):
 
         if user.check_password(password):
             return user
+
+class CustomHeaderBackend(RemoteUserBackend):
+    def clean_username(self, username):
+        if settings.REMOTE_USER_HEADER_TYPE == None: return None
+        elif settings.REMOTE_USER_HEADER_TYPE == "ID": return username
+
+        #else, it's the email address
+        try:
+            return User.objects.get(email=username).username
+        except User.DoesNotExist:
+            return views._make_user(username).username

--- a/hc/accounts/backends.py
+++ b/hc/accounts/backends.py
@@ -42,8 +42,11 @@ class EmailBackend(BasicBackend):
 
 class CustomHeaderBackend(RemoteUserBackend):
     def clean_username(self, username):
-        if settings.REMOTE_USER_HEADER_TYPE == None: return None
-        elif settings.REMOTE_USER_HEADER_TYPE == "ID": return username
+        if settings.REMOTE_USER_HEADER_TYPE == "ID": return username
+
+        # "EMAIL" and "ID" are the only two values that should reach here
+        if settings.REMOTE_USER_HEADER_TYPE != "EMAIL": 
+            raise Exception(f"Unexpected value for REMOTE_USER_HEADER_TYPE ({settings.REMOTE_USER_HEADER_TYPE})!")
 
         #else, it's the email address
         try:

--- a/hc/accounts/middleware.py
+++ b/hc/accounts/middleware.py
@@ -19,3 +19,8 @@ from django.contrib.auth.middleware import RemoteUserMiddleware
 
 class CustomHeaderMiddleware(RemoteUserMiddleware):
     header = settings.REMOTE_USER_HEADER
+
+    def process_request(self, request):
+        if settings.REMOTE_USER_HEADER_TYPE == None: return None
+        if settings.REMOTE_USER_HEADER_TYPE == "": return None
+        return super().process_request(request)

--- a/hc/accounts/middleware.py
+++ b/hc/accounts/middleware.py
@@ -1,7 +1,8 @@
-from hc.accounts.models import Profile
+from django.contrib import auth
 from django.contrib.auth.middleware import RemoteUserMiddleware
-from django.contrib.auth.backends import RemoteUserBackend
 from django.conf import settings
+
+from hc.accounts.models import Profile
 
 
 class TeamAccessMiddleware(object):
@@ -15,12 +16,48 @@ class TeamAccessMiddleware(object):
         request.profile = Profile.objects.for_user(request.user)
         return self.get_response(request)
 
-from django.contrib.auth.middleware import RemoteUserMiddleware
 
 class CustomHeaderMiddleware(RemoteUserMiddleware):
-    header = settings.REMOTE_USER_HEADER
+    """
+    Middleware for utilizing Web-server-provided authentication.
+
+    If request.user is not authenticated, then this middleware:
+    - looks for an email address in request.META[settings.REMOTE_USER_HEADER]
+    - looks up and automatically logs in the user with a matching email
+
+    """
 
     def process_request(self, request):
-        if settings.REMOTE_USER_HEADER_TYPE == None: return None
-        if settings.REMOTE_USER_HEADER_TYPE == "": return None
-        return super().process_request(request)
+        if not settings.REMOTE_USER_HEADER:
+            return
+
+        # Make sure AuthenticationMiddleware is installed
+        assert hasattr(request, "user")
+
+        email = request.META.get(settings.REMOTE_USER_HEADER)
+        if not email:
+            # If specified header doesn't exist or is empty then log out any
+            # authenticated user and return
+            if request.user.is_authenticated:
+                auth.logout(request)
+            return
+
+        # If the user is already authenticated and that user is the user we are
+        # getting passed in the headers, then the correct user is already
+        # persisted in the session and we don't need to continue.
+        if request.user.is_authenticated:
+            if request.user.email == email:
+                return
+            else:
+                # An authenticated user is associated with the request, but
+                # it does not match the authorized user in the header.
+                auth.logout(request)
+
+        # We are seeing this user for the first time in this session, attempt
+        # to authenticate the user.
+        user = auth.authenticate(request, remote_user_email=email)
+        if user:
+            # User is valid.  Set request.user and persist user in the session
+            # by logging the user in.
+            request.user = user
+            auth.login(request, user)

--- a/hc/accounts/middleware.py
+++ b/hc/accounts/middleware.py
@@ -1,4 +1,7 @@
 from hc.accounts.models import Profile
+from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.contrib.auth.backends import RemoteUserBackend
+from django.conf import settings
 
 
 class TeamAccessMiddleware(object):
@@ -11,3 +14,8 @@ class TeamAccessMiddleware(object):
 
         request.profile = Profile.objects.for_user(request.user)
         return self.get_response(request)
+
+from django.contrib.auth.middleware import RemoteUserMiddleware
+
+class CustomHeaderMiddleware(RemoteUserMiddleware):
+    header = settings.REMOTE_USER_HEADER

--- a/hc/accounts/tests/test_remote_user_header_login.py
+++ b/hc/accounts/tests/test_remote_user_header_login.py
@@ -1,0 +1,34 @@
+from unittest.mock import patch
+from django.test.utils import override_settings
+from hc.test import BaseTestCase
+from hc.accounts.middleware import CustomHeaderMiddleware
+from django.conf import settings
+
+class RemoteUserHeaderTestCase(BaseTestCase):
+    @override_settings(REMOTE_USER_HEADER_TYPE="")
+    def test_it_does_nothing_when_disabled(self):
+        r = self.client.get("/accounts/profile/", AUTH_USER="alice@example.org")
+        self.assertRedirects(r, "/accounts/login/?next=/accounts/profile/")
+
+    @override_settings(REMOTE_USER_HEADER_TYPE="EMAIL")
+    def test_it_logs_users_in_by_email(self):
+        r = self.client.get("/accounts/profile/", AUTH_USER="alice@example.org")
+        self.assertContains(r, "alice@example.org")
+
+    @override_settings(REMOTE_USER_HEADER="HTTP_AUTH_TEST", REMOTE_USER_HEADER_TYPE="EMAIL")
+    def test_it_allows_customizing_the_header(self):
+        # patch the CustomHeaderMiddleware's header value since it's static and
+        # won't be updated automatically --- this is OK outside of test, since
+        # that value shouldn't change after instantiation anyway
+        _old_header = CustomHeaderMiddleware.header
+        CustomHeaderMiddleware.header = settings.REMOTE_USER_HEADER
+        r = self.client.get("/accounts/profile/", HTTP_AUTH_TEST="alice@example.org")
+        self.assertContains(r, "alice@example.org")
+
+        # un-patch the header
+        CustomHeaderMiddleware.header = _old_header
+
+    @override_settings(REMOTE_USER_HEADER_TYPE="ID")
+    def test_it_logs_users_in_by_id(self):
+        r = self.client.get("/accounts/profile/", AUTH_USER="alice")
+        self.assertContains(r, "alice@example.org")

--- a/hc/accounts/tests/test_remote_user_header_login.py
+++ b/hc/accounts/tests/test_remote_user_header_login.py
@@ -1,34 +1,56 @@
 from unittest.mock import patch
+
+from django.contrib.auth.models import User
 from django.test.utils import override_settings
 from hc.test import BaseTestCase
-from hc.accounts.middleware import CustomHeaderMiddleware
-from django.conf import settings
 
+
+@override_settings(
+    REMOTE_USER_HEADER="AUTH_USER",
+    AUTHENTICATION_BACKENDS=("hc.accounts.backends.CustomHeaderBackend",),
+)
 class RemoteUserHeaderTestCase(BaseTestCase):
-    @override_settings(REMOTE_USER_HEADER_TYPE="")
-    def test_it_does_nothing_when_disabled(self):
+    @override_settings(REMOTE_USER_HEADER=None)
+    def test_it_does_nothing_when_not_configured(self):
         r = self.client.get("/accounts/profile/", AUTH_USER="alice@example.org")
         self.assertRedirects(r, "/accounts/login/?next=/accounts/profile/")
 
-    @override_settings(REMOTE_USER_HEADER_TYPE="EMAIL")
-    def test_it_logs_users_in_by_email(self):
+    def test_it_logs_user_in(self):
         r = self.client.get("/accounts/profile/", AUTH_USER="alice@example.org")
         self.assertContains(r, "alice@example.org")
 
-    @override_settings(REMOTE_USER_HEADER="HTTP_AUTH_TEST", REMOTE_USER_HEADER_TYPE="EMAIL")
-    def test_it_allows_customizing_the_header(self):
-        # patch the CustomHeaderMiddleware's header value since it's static and
-        # won't be updated automatically --- this is OK outside of test, since
-        # that value shouldn't change after instantiation anyway
-        _old_header = CustomHeaderMiddleware.header
-        CustomHeaderMiddleware.header = settings.REMOTE_USER_HEADER
-        r = self.client.get("/accounts/profile/", HTTP_AUTH_TEST="alice@example.org")
+    def test_it_does_nothing_when_header_not_set(self):
+        r = self.client.get("/accounts/profile/")
+        self.assertRedirects(r, "/accounts/login/?next=/accounts/profile/")
+
+    def test_it_does_nothing_when_header_is_empty_string(self):
+        r = self.client.get("/accounts/profile/", AUTH_USER="")
+        self.assertRedirects(r, "/accounts/login/?next=/accounts/profile/")
+
+    def test_it_creates_user(self):
+        r = self.client.get("/accounts/profile/", AUTH_USER="dave@example.org")
+        self.assertContains(r, "dave@example.org")
+
+        q = User.objects.filter(email="dave@example.org")
+        self.assertTrue(q.exists())
+
+    def test_it_logs_out_another_user_when_header_is_empty_string(self):
+        self.client.login(remote_user_email="bob@example.org")
+
+        r = self.client.get("/accounts/profile/", AUTH_USER="")
+        self.assertRedirects(r, "/accounts/login/?next=/accounts/profile/")
+
+    def test_it_logs_out_another_user(self):
+        self.client.login(remote_user_email="bob@example.org")
+
+        r = self.client.get("/accounts/profile/", AUTH_USER="alice@example.org")
         self.assertContains(r, "alice@example.org")
 
-        # un-patch the header
-        CustomHeaderMiddleware.header = _old_header
+    def test_it_handles_already_logged_in_user(self):
+        self.client.login(remote_user_email="alice@example.org")
 
-    @override_settings(REMOTE_USER_HEADER_TYPE="ID")
-    def test_it_logs_users_in_by_id(self):
-        r = self.client.get("/accounts/profile/", AUTH_USER="alice")
-        self.assertContains(r, "alice@example.org")
+        with patch("hc.accounts.middleware.auth") as mock_auth:
+            r = self.client.get("/accounts/profile/", AUTH_USER="alice@example.org")
+
+            self.assertFalse(mock_auth.authenticate.called)
+            self.assertContains(r, "alice@example.org")

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -58,12 +58,6 @@ INSTALLED_APPS = (
     "hc.payments",
 )
 
-REMOTE_USER_HEADER = os.getenv("REMOTE_USER_HEADER", "AUTH_USER")
-REMOTE_USER_HEADER_TYPE = os.getenv("REMOTE_USER_HEADER_TYPE", "").upper()
-if REMOTE_USER_HEADER_TYPE not in ["EMAIL", "ID", ""]: 
-    warnings.warn(f"Unknown REMOTE_USER_HEADER_TYPE '{REMOTE_USER_HEADER_TYPE}'! header-based authentication has been disabled.")
-    REMOTE_USER_HEADER_TYPE = None
-if REMOTE_USER_HEADER_TYPE == "": REMOTE_USER_HEADER_TYPE = None
 
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
@@ -81,8 +75,11 @@ MIDDLEWARE = (
 AUTHENTICATION_BACKENDS = (
     "hc.accounts.backends.EmailBackend",
     "hc.accounts.backends.ProfileBackend",
-    "hc.accounts.backends.CustomHeaderBackend",
 )
+
+REMOTE_USER_HEADER = os.getenv("REMOTE_USER_HEADER")
+if REMOTE_USER_HEADER:
+    AUTHENTICATION_BACKENDS = ("hc.accounts.backends.CustomHeaderBackend",)
 
 ROOT_URLCONF = "hc.urls"
 

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -60,7 +60,10 @@ INSTALLED_APPS = (
 
 REMOTE_USER_HEADER = os.getenv("REMOTE_USER_HEADER", "AUTH_USER")
 REMOTE_USER_HEADER_TYPE = os.getenv("REMOTE_USER_HEADER_TYPE", "").upper()
-if REMOTE_USER_HEADER_TYPE not in ["EMAIL", "ID"]: REMOTE_USER_HEADER_TYPE = None
+if REMOTE_USER_HEADER_TYPE not in ["EMAIL", "ID", ""]: 
+    warnings.warn(f"Unknown REMOTE_USER_HEADER_TYPE '{REMOTE_USER_HEADER_TYPE}'! header-based authentication has been disabled.")
+    REMOTE_USER_HEADER_TYPE = None
+if REMOTE_USER_HEADER_TYPE == "": REMOTE_USER_HEADER_TYPE = None
 
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -58,12 +58,17 @@ INSTALLED_APPS = (
     "hc.payments",
 )
 
+REMOTE_USER_HEADER = os.getenv("REMOTE_USER_HEADER", "AUTH_USER")
+REMOTE_USER_HEADER_TYPE = os.getenv("REMOTE_USER_HEADER_TYPE", "").upper()
+if REMOTE_USER_HEADER_TYPE not in ["EMAIL", "ID"]: REMOTE_USER_HEADER_TYPE = None
+
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "hc.accounts.middleware.CustomHeaderMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.locale.LocaleMiddleware",
@@ -73,6 +78,7 @@ MIDDLEWARE = (
 AUTHENTICATION_BACKENDS = (
     "hc.accounts.backends.EmailBackend",
     "hc.accounts.backends.ProfileBackend",
+    "hc.accounts.backends.CustomHeaderBackend",
 )
 
 ROOT_URLCONF = "hc.urls"


### PR DESCRIPTION
I wanted to self-host healthchecks and integrate it with my central authentication system (see #185), so rather than develop something specific to my needs, I added support for HTTP header-based authentication. This way, people can integrate whatever auth system they want (LDAP, mTLS, SAML, OAuth, whatever) at the reverse proxy level and remove the need for healthchecks to care about the implementation details.

I added two new settings (with corresponding environment variables):

1. `REMOTE_USER_HEADER` &mdash; set this to the header you wish to authenticate with. HTTP headers will be prefixed with `HTTP_` and have any dashes converted to underscores. Headers without that prefix can be set by the WSGI server itself only, which is more secure.
2. `REMOTE_USER_HEADER_TYPE` &mdash; If set to `EMAIL`, the specified header will be treated as the user's email. If set to `ID`, the specified header will be set to the user's UUID. Any other value (including empty, the default) disables header-based authentication.