### PR TITLE
docs: fix simple typo, libary -> library

### DIFF
--- a/templates/docs/python.html
+++ b/templates/docs/python.html
@@ -10,7 +10,7 @@
 </code></pre></div>
 
 
-<p>Otherwise, you can use the urllib module from Python 3 standard libary:</p>
+<p>Otherwise, you can use the urllib module from Python 3 standard library:</p>
 <div class="python highlight"><pre><span></span><code><span class="kn">import</span> <span class="nn">socket</span>
 <span class="kn">import</span> <span class="nn">urllib.request</span>
 

--- a/templates/docs/python.md
+++ b/templates/docs/python.md
@@ -12,7 +12,7 @@ except requests.RequestException as e:
     print("Ping failed: %s" % e)
 ```
 
-Otherwise, you can use the urllib module from Python 3 standard libary:
+Otherwise, you can use the urllib module from Python 3 standard library:
 
 ```python
 import socket


### PR DESCRIPTION
There is a small typo in templates/docs/python.md.

Should read `library` rather than `libary`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md