### PR TITLE
Changing static height and width to be constraints

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -77,16 +77,16 @@
             {% elif request.user.is_authenticated%}
                 <img
                     id="logo"
-                    height="50"
-                    width="59"
+                    max-height="50"
+                    max-width="59"
                     src="{% static 'img/logo.png'%}"
                     srcset="{% static 'img/logo.png'%} 1x, {% static 'img/logo@2x.png'%} 2x"
                     alt="{{ site_name }}">
             {% else %}
                 <img
                     id="logo"
-                    height="50"
-                    width="200"
+                    max-height="50"
+                    max-width="200"
                     src="{% static 'img/logo-full.png'%}"
                     srcset="{% static 'img/logo-full.png'%} 1x, {% static 'img/logo-full@2x.png'%} 2x"
                     alt="{{ site_name }}">


### PR DESCRIPTION
This commit allows for logo.png (and it's scaled alternates) to keep their own proportions while still being constrained in the existing bounds of the base layout for each page. Without this change, custom logos that don't exactly match the proportions (50x59, 50x200) are skewed to fill the bounds.