### PR TITLE
fix line height on request body

### DIFF
--- a/static/css/ping_details.css
+++ b/static/css/ping_details.css
@@ -24,6 +24,7 @@
     padding: 16px;
     margin: 0;
     max-height: 500px;
+    line-height: 1em;
 }
 
 #email-body-html-iframe {


### PR DESCRIPTION
The line height in the ping request body is being set by the bootstrap.css body tag to 1.42857143. The additional line height makes request bodies with unicode characters have spacing between lines that shouldn't be there.
Before:
![Before Commit](https://user-images.githubusercontent.com/544915/109405207-9da41000-7933-11eb-9c8d-118e5a4a7c79.png)
After:
![After Commit](https://user-images.githubusercontent.com/544915/109405203-97ae2f00-7933-11eb-9d77-7e531458a47e.png)
