### PR TITLE
[DOCKER] Fix failing docker build on arm due to cryptography trying to build rust

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9
 
 RUN useradd --system hc
 ENV PYTHONUNBUFFERED=1
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 WORKDIR /opt/healthchecks
 
 COPY requirements.txt /tmp


### PR DESCRIPTION
Build on my raspberry pi 4 (`armhf`) was failing due to the cryptography python package trying to build Rust dependency. Find below a snippet taken from the build logs:
```
  running build_rust
  
      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation.html for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq.html
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation.html#rust
      5) If you are experiencing issues with Rust for *this release only* you may
         set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
      =============================DEBUG ASSISTANCE=============================
  
  error: can't find Rust compiler
  
  If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
  
  To update pip, run:
  
      pip install --upgrade pip
  
  and then retry package installation.
  
  If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
  
  This package requires Rust >=1.41.0.
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
```

My fix is greatly (to say the least) inspired by https://github.com/docker/compose/issues/8105#issuecomment-775879420 . It consists simply of adding `ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1` in the `Dockerfile` prior to the pip installation.

I don't think that the Rust dependency was ever used in this project, so it shouldn't impact the vast majority of users.
I also believe, that if someone needs it, he probably created his own Dockerfile to handle his scenarios.

I have it confirmed working on both my `armhf` and my `amd64` machines.
