### PR TITLE
manage.py should point to "python3" instead of "python".

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 


### PR DESCRIPTION
Without this fix, the following error occurs:

> $ sudo docker-compose exec healthchecks /app/healthchecks/manage.py prunepings
> env: ‘python’: No such file or directory