### PR TITLE
Close response body in Go example as recommended in http package documentation

### DIFF
--- a/templates/docs/go.md
+++ b/templates/docs/go.md
@@ -14,10 +14,11 @@ func main() {
         Timeout: 10 * time.Second,
     }
 
-    _, err := client.Head("PING_URL")
+    resp, err := client.Head("PING_URL")
     if err != nil {
         fmt.Printf("%s", err)
     }
+    resp.Body.Close()
 }
 
 ```


### PR DESCRIPTION
The official Go documentation on the http package recommends that caller must close the body of the response.

https://golang.org/pkg/net/http/#Response

```
    // ...
    // The http Client and Transport guarantee that Body is always
    // non-nil, even on responses without a body or responses with
    // a zero-length body. It is the caller's responsibility to
    // close Body. The default HTTP client's Transport may not
    // reuse HTTP/1.x "keep-alive" TCP connections if the Body is
    // not read to completion and closed.
    // ...
    Body io.ReadCloser
```

Since the example already demonstrates the sane practice of not using the default HTTP client, it would make the example _complete_ if one more line is added to close the response body.

I suppose in a lot of use cases, this ping will happen from within a loop...? If that is the case, this would be even more relevant.
