### PR TITLE
feat: manager role

### DIFF
--- a/hc/accounts/forms.py
+++ b/hc/accounts/forms.py
@@ -6,7 +6,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import User
-from hc.accounts.models import REPORT_CHOICES
+from hc.accounts.models import REPORT_CHOICES, Member
 from hc.api.models import TokenBucket
 import pytz
 
@@ -136,7 +136,7 @@ class ChangeEmailForm(forms.Form):
 
 class InviteTeamMemberForm(forms.Form):
     email = LowercaseEmailField(max_length=254)
-    rw = forms.BooleanField(required=False)
+    role = forms.ChoiceField(choices=Member.Role.choices)
 
 
 class RemoveTeamMemberForm(forms.Form):

--- a/hc/accounts/migrations/0043_add_role_manager.py
+++ b/hc/accounts/migrations/0043_add_role_manager.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+from hc.accounts.models import Member
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0042_remove_member_rw'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='member',
+            name='role',
+            field=models.CharField(choices=Member.Role.choices, default=Member.Role.REGULAR, max_length=1),
+        ),
+    ]

--- a/hc/test.py
+++ b/hc/test.py
@@ -36,7 +36,7 @@ class BaseTestCase(TestCase):
         self.bobs_profile.save()
 
         self.bobs_membership = Member.objects.create(
-            user=self.bob, project=self.project
+            user=self.bob, project=self.project, role=Member.Role.REGULAR
         )
 
         # Charlie should have no access to Alice's stuff

--- a/templates/accounts/project.html
+++ b/templates/accounts/project.html
@@ -169,7 +169,7 @@
                             <td class="email">{{ m.user.email }}</td>
                             <td>{{ m.get_role_display}}</td>
                             <td>
-                                {% if is_owner %}
+                                {% if is_manager and m.user != request.user %}
                                 <a
                                     href="#"
                                     data-email="{{ m.user.email }}"
@@ -179,7 +179,7 @@
                         </tr>
                         {% endfor %}
 
-                        {% if is_owner and invite_suggestions %}
+                        {% if is_manager and invite_suggestions %}
                         <tr id="suggestions-row">
                             <td colspan="3">
                                 Add Users from Other Teams
@@ -210,7 +210,7 @@
 
                 <br />
 
-                {% if is_owner %}
+                {% if is_manager %}
                 {% if project.can_invite_new_users %}
                 <a
                     href="#"
@@ -401,8 +401,19 @@
                         <label class="radio-container">
                             <input
                                 type="radio"
-                                name="rw"
-                                value="1"
+                                name="role"
+                                value="m">
+                            <span class="radiomark"></span>
+                            Manager
+                            <span class="help-block">
+                                Can invite/remove other members.
+                            </span>
+                        </label>
+                        <label class="radio-container">
+                            <input
+                                type="radio"
+                                name="role"
+                                value="w"
                                 checked>
                             <span class="radiomark"></span>
                             Team Member
@@ -410,8 +421,8 @@
                         <label class="radio-container">
                             <input
                                 type="radio"
-                                name="rw"
-                                value="">
+                                name="role"
+                                value="r">
                             <span class="radiomark"></span>
                             Read-only
                             <span class="help-block">


### PR DESCRIPTION
This PR adds a manager permission as mentioned in the related issue.

The boolean field `Member.rw` is migrated to the enum field `Member.permission`.
Managers are allowed to invite/remove team members except themselves.

Closes #484