### PR TITLE
Fix db-data volume in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   db:
     image: postgres:12
     volumes:
-      - db-data:/var/lib/postgresql
+      - db-data:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=$DB_NAME
       - POSTGRES_PASSWORD=$DB_PASSWORD


### PR DESCRIPTION
Use data folder otherwise a second volume is created that becomes orphaned after a docker-compose down.
That means that, currently, after each up&down you start with a fresh database.