### PR TITLE
Use slim version of the container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,8 @@ ENV PYTHONUNBUFFERED=1
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 WORKDIR /opt/healthchecks
 
+RUN apt update && apt install -y libpq-dev build-essential && rm -rf /var/apt/cache
+
 COPY requirements.txt /tmp
 RUN \
     pip install --no-cache-dir -r /tmp/requirements.txt && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 RUN useradd --system hc
 ENV PYTHONUNBUFFERED=1
@@ -20,4 +20,3 @@ RUN \
 USER hc
 
 CMD [ "uwsgi", "/opt/healthchecks/docker/uwsgi.ini"]
-

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9-slim-buster
 
 RUN useradd --system hc
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
This massively reduces the size of the container, by removing things which aren't needed, and not downloading them in the first place.

Required a special case for `psycopg2`, as `libpq-dev` isn't included in debian slim.

`python:3.9`: 332mb compressed, 911mb uncompressed.
`python:3.9-slim`: 43mb compressed, 122mb uncompressed.

Quite a saving by doing almost nothing.