### PR TITLE
Fix requests package version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-compressor==3.0
 fido2==0.9.2
 psycopg2==2.9.1
 pyotp==2.6.0
-requests==2.26.0
+requests>=2.26.0
 segno==1.3.3
 statsd==3.3.0
 whitenoise==5.3.0


### PR DESCRIPTION
This is related to https://github.com/healthchecks/healthchecks/issues/594

Updating the package to v2.27.0 in requirements.txt failed about an hour after creating the original issue because v2.27.1 was released. For that reason I just changed it to >= v2.26.0. The docker image builds for me with this change.