### PR TITLE
Prevent localization in non english language

### DIFF
--- a/templates/front/details.html
+++ b/templates/front/details.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load compress humanize static hc_extras %}
+{% load compress humanize l10n static hc_extras %}
 
 {% block title %}{{ check|down_title }}{% endblock %}
 
@@ -217,8 +217,8 @@
                     data-code="{{ check.code }}"
                     data-status-url="{% url 'hc-status-single' check.code %}"
                     data-kind="{{ check.kind }}"
-                    data-timeout="{{ check.timeout.total_seconds }}"
-                    data-grace="{{ check.grace.total_seconds }}"
+                    data-timeout="{{ check.timeout.total_seconds|unlocalize }}"
+                    data-grace="{{ check.grace.total_seconds|unlocalize }}"
                     data-schedule="{{ check.schedule }}"
                     data-tz="{{ check.tz }}">
                     Change Schedule&hellip;</button>


### PR DESCRIPTION
This allows to change the schedule of a check when using a non-English language.

When healthcheck is using a language like french, the total_seconds from the duration is formatted to the current locale.

This change `3600` to `3600,00` which prevent editing and raise an error 400. You can re specify each time the 2 values, but it's a lot of work.

This pull request prevents this behavior and allow you to edit directly.