### PR TITLE
Prettified matrix notifications

### DIFF
--- a/templates/integrations/matrix_description.html
+++ b/templates/integrations/matrix_description.html
@@ -1,6 +1,9 @@
 {% load humanize %}
 {% if check.status == "down" %}
-    {{ check.name_then_code }} is DOWN. Last ping was {{ check.last_ping|naturaltime }}.
+    [🔴 DOWN] - {{ check.name_then_code }}
+Last ping was {{ check.last_ping|naturaltime }}.
+
 {% else %}
-    {{ check.name_then_code }} is now UP.
+    [🟢 UP] - {{ check.name_then_code }}
+
 {% endif %}

--- a/templates/integrations/matrix_description_formatted.html
+++ b/templates/integrations/matrix_description_formatted.html
@@ -1,6 +1,7 @@
 {% load humanize %}
 {% if check.status == "down" %}
-    <b>{{ check.name_then_code }}</b> is <b>DOWN</b>. Last ping was {{ check.last_ping|naturaltime }}.
+    [🔴 DOWN] - <b>{{ check.name_then_code }}</b><br>
+Last ping was {{ check.last_ping|naturaltime }}.<br><br>
 {% else %}
-    <b>{{ check.name_then_code }}</b> is now <b>UP</b>.
+    [🟢 UP] - <b>{{ check.name_then_code }}</b><br><br>
 {% endif %}


### PR DESCRIPTION
Just made the matrix notifications a bit prettier, since they were quite hard to notice among others in my healthcheck notifications matrix room.
IMHO this seems like a decent template, perhaps for other notification integrations?

Before:
![image](https://user-images.githubusercontent.com/59068073/159450111-8823a4f0-3feb-41a8-b05d-afb278ecb2be.png)

After:
![image](https://user-images.githubusercontent.com/59068073/159450498-a868b531-0d47-41f6-ae23-30ebf32cc9ce.png)


