### PR TITLE
Add `hc_check_started` prometheus metrics

### DIFF
--- a/hc/front/views.py
+++ b/hc/front/views.py
@@ -1961,6 +1961,14 @@ def metrics(request, code, key):
             value = 0 if check.get_status() == "down" else 1
             yield TMPL % (esc(check.name), esc(check.tags), check.unique_key, value)
 
+        yield "\n"
+        yield "# HELP hc_check_started Whether the check is currently started in progress (1 for yes, 0 for no).\n"
+        yield "# TYPE hc_check_started gauge\n"
+        TMPL = """hc_check_started{name="%s", tags="%s", unique_key="%s"} %d\n"""
+        for check in checks:
+            value = 1 if check.get_status(with_started=True) == "started" else 0
+            yield TMPL % (esc(check.name), esc(check.tags), check.unique_key, value)
+
         tags_statuses, num_down = _tags_statuses(checks)
         yield "\n"
         yield "# HELP hc_tag_up Whether all checks with this tag are up (1 for yes, 0 for no).\n"


### PR DESCRIPTION
This is simple fix adds another metric to prometheus endpoint - `hc_check_in_progress`. Its purpose is to return `1` for checks which are currently in progress (marked as `started`, and not finished or failed). 

The main purpose are prometheus alerts. For example, in my case some of the cron tasks use 100% CPU, and it's normal - which means, I don't want to receive alerts from prometheus/alertmanager about CPU usage during this time. Thanks to this simple metric, I can add simple rule like `node_load5 > 8 and on() hc_check_in_progress{name="my-heavy-cron-job"} == 0` and never be bothered unnecessarily again :)