### PR TITLE
Add last_start to Checks API

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -252,6 +252,7 @@ class Check(models.Model):
             "grace": int(self.grace.total_seconds()),
             "n_pings": self.n_pings,
             "status": self.get_status(with_started=True),
+            "last_start": self.last_start,
             "last_ping": isostring(self.last_ping),
             "next_ping": isostring(self.get_grace_start()),
             "manual_resume": self.manual_resume,

--- a/hc/api/tests/test_get_check.py
+++ b/hc/api/tests/test_get_check.py
@@ -34,7 +34,7 @@ class GetCheckTestCase(BaseTestCase):
         self.assertEqual(r["Access-Control-Allow-Origin"], "*")
 
         doc = r.json()
-        self.assertEqual(len(doc), 16)
+        self.assertEqual(len(doc), 17)
 
         self.assertEqual(doc["slug"], "alice-1")
         self.assertEqual(doc["timeout"], 3600)
@@ -63,7 +63,7 @@ class GetCheckTestCase(BaseTestCase):
         self.assertEqual(r["Access-Control-Allow-Origin"], "*")
 
         doc = r.json()
-        self.assertEqual(len(doc), 16)
+        self.assertEqual(len(doc), 17)
 
         self.assertEqual(doc["timeout"], 3600)
         self.assertEqual(doc["grace"], 900)


### PR DESCRIPTION
Adds `last_start` field to `GET /v1/checks/{id-or-slug}`.

Fixes #633 