### PR TITLE
Add support for multiple RCPT TO in incoming email

### DIFF
--- a/hc/api/management/commands/smtpd.py
+++ b/hc/api/management/commands/smtpd.py
@@ -61,8 +61,9 @@ class Listener(SMTPServer):
         # get a new db connection in case the old one has timed out:
         connections.close_all()
 
-        result = _process_message(peer[0], mailfrom, rcpttos[0], data)
-        self.stdout.write(result)
+        for rcptto in rcpttos:
+            result = _process_message(peer[0], mailfrom, rcptto, data)
+            self.stdout.write(result)
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Found a particular scenario where the software (Veeam Agent) sending the email notifications that also have to be processed as pings, allows to send to one fixed recipient address only.
If I forward these emails, from that address to the multiple checks/recipients that I need (filtering via subject in Healthchecks), it sends them in one connection using multiple RCPT TOs, and Healthchecks just processes the first one.

This little change allows it to process multiple RCPT addresses and may be useful for this particular case and others.