### PR TITLE
Add support for SMTP with implicit TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,23 @@ Healthchecks must be able to send email messages, so it can send out login
 links and alerts to users. Specify your SMTP credentials using the following
 environment variables:
 
-```python
-EMAIL_HOST = "your-smtp-server-here.com"
-EMAIL_PORT = 587
-EMAIL_HOST_USER = "smtp-username"
-EMAIL_HOST_PASSWORD = "smtp-password"
-EMAIL_USE_TLS = True
-```
+- Implicit TLS (*recommended*):
+    ```python
+    EMAIL_HOST = "your-smtp-server-here.com"
+    EMAIL_PORT = 465
+    EMAIL_HOST_USER = "smtp-username"
+    EMAIL_HOST_PASSWORD = "smtp-password"
+    EMAIL_USE_SSL = True
+    ```
+
+- Explicit TLS:
+    ```python
+    EMAIL_HOST = "your-smtp-server-here.com"
+    EMAIL_PORT = 587
+    EMAIL_HOST_USER = "smtp-username"
+    EMAIL_HOST_PASSWORD = "smtp-password"
+    EMAIL_USE_TLS = True
+    ```
 
 For more information, have a look at Django documentation,
 [Sending Email](https://docs.djangoproject.com/en/1.10/topics/email/) section.

--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ environment variables:
     EMAIL_PORT = 465
     EMAIL_HOST_USER = "smtp-username"
     EMAIL_HOST_PASSWORD = "smtp-password"
+    EMAIL_USE_TLS = False
     EMAIL_USE_SSL = True
     ```
+
+    Port 465 should be the preferred method according to [RFC8314 Section 3.3: Implicit TLS for SMTP Submission](https://tools.ietf.org/html/rfc8314#section-3.3). Be sure to use a TLS certificate and not an SSL one.
 
 - Explicit TLS:
     ```python

--- a/hc/local_settings.py.example
+++ b/hc/local_settings.py.example
@@ -26,7 +26,8 @@
 
 # Email
 # EMAIL_HOST = "your-smtp-server-here.com"
-# EMAIL_PORT = 465
+# EMAIL_PORT = 587
 # EMAIL_HOST_USER = "username"
 # EMAIL_HOST_PASSWORD = "password"
-# EMAIL_USE_SSL = True
+# EMAIL_USE_TLS = True
+# EMAIL_USE_SSL = False

--- a/hc/local_settings.py.example
+++ b/hc/local_settings.py.example
@@ -26,7 +26,7 @@
 
 # Email
 # EMAIL_HOST = "your-smtp-server-here.com"
-# EMAIL_PORT = 587
+# EMAIL_PORT = 465
 # EMAIL_HOST_USER = "username"
 # EMAIL_HOST_PASSWORD = "password"
-# EMAIL_USE_TLS = True
+# EMAIL_USE_SSL = True

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -181,10 +181,11 @@ WHITENOISE_IMMUTABLE_FILE_TEST = immutable_file_test
 
 # SMTP credentials for sending email
 EMAIL_HOST = os.getenv("EMAIL_HOST", "")
-EMAIL_PORT = envint("EMAIL_PORT", "587")
+EMAIL_PORT = envint("EMAIL_PORT", "465")
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
-EMAIL_USE_TLS = envbool("EMAIL_USE_TLS", "True")
+EMAIL_USE_TLS = envbool("EMAIL_USE_TLS", "False")
+EMAIL_USE_SSL = envbool("EMAIL_USE_SSL", "False")
 EMAIL_USE_VERIFICATION = envbool("EMAIL_USE_VERIFICATION", "True")
 
 # WebAuthn

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -181,10 +181,10 @@ WHITENOISE_IMMUTABLE_FILE_TEST = immutable_file_test
 
 # SMTP credentials for sending email
 EMAIL_HOST = os.getenv("EMAIL_HOST", "")
-EMAIL_PORT = envint("EMAIL_PORT", "465")
+EMAIL_PORT = envint("EMAIL_PORT", "587")
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", "")
-EMAIL_USE_TLS = envbool("EMAIL_USE_TLS", "False")
+EMAIL_USE_TLS = envbool("EMAIL_USE_TLS", "True")
 EMAIL_USE_SSL = envbool("EMAIL_USE_SSL", "False")
 EMAIL_USE_VERIFICATION = envbool("EMAIL_USE_VERIFICATION", "True")
 

--- a/templates/docs/self_hosted_configuration.md
+++ b/templates/docs/self_hosted_configuration.md
@@ -169,6 +169,13 @@ Default: `True`
 This is a standard Django setting, read more in
 [Django documentation](https://docs.djangoproject.com/en/4.0/ref/settings/#email-use-tls).
 
+## `EMAIL_USE_SSL` {: #EMAIL_USE_SSL}
+
+Default: `False`
+
+This is a standard Django setting, read more in
+[Django documentation](https://docs.djangoproject.com/en/4.0/ref/settings/#email-use-ssl).
+
 ## `EMAIL_USE_VERIFICATION` {: #EMAIL_USE_VERIFICATION }
 
 Default: `True`


### PR DESCRIPTION
I've added `EMAIL_USE_SSL` to the environment variables handled by `settings.py` and changed the default SMTP port to `465` which is the recommended one over `587`. I've also set their default value to `False` as they can't be both `True` at the same time. A user who wants to use either one has to specify the correct one.

I've also updated the `README.md` with the new configuration setup.