### PR TITLE
Remove port portion of remote_addr to fix Azure deployments

### DIFF
--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -379,6 +379,8 @@ class Check(models.Model):
             ping.kind = action
 
         ping.remote_addr = remote_addr
+        if ':' in remote_addr:
+            ping.remote_addr = remote_addr.split(':')[0] # If the address contains a port (like in Azure), remove the port portion
         ping.scheme = scheme
         ping.method = method
         # If User-Agent is longer than 200 characters, truncate it:

--- a/hc/api/models.py
+++ b/hc/api/models.py
@@ -379,7 +379,7 @@ class Check(models.Model):
             ping.kind = action
 
         ping.remote_addr = remote_addr
-        if ':' in remote_addr:
+        if ':' in remote_addr and '.' in remote_addr:
             ping.remote_addr = remote_addr.split(':')[0] # If the address contains a port (like in Azure), remove the port portion
         ping.scheme = scheme
         ping.method = method


### PR DESCRIPTION
In an Azure deployment, there were issues saving ping objects to the database because the addresses appear to come in with ports attached to them (123.123.123.123:5314), which breaks the [GenericIPAddressField](https://docs.djangoproject.com/en/4.1/ref/forms/fields/#genericipaddressfield) constraint on the [Ping model](https://github.com/healthchecks/healthchecks/blob/11997e75c8b82981537234f236e0abb878afeeee/hc/api/models.py#L497). This had the following results: 
- Pings not actually saving to the database
- Hitting ping endpoints would result in 500 status codes
- Check's status would change, but no logs would appear on the page

I was able to make this change locally and push a container based on it into Azure and the fix works.