### PR TITLE
add body to slack notification

### DIFF
--- a/hc/api/transports.py
+++ b/hc/api/transports.py
@@ -346,8 +346,9 @@ class Slack(HttpTransport):
     def notify(self, check, notification=None) -> None:
         if not settings.SLACK_ENABLED:
             raise TransportError("Slack notifications are not enabled.")
-
-        text = tmpl("slack_message.json", check=check, ping=self.last_ping(check))
+        ping = self.last_ping(check)
+        body = get_ping_body(ping)
+        text = tmpl("slack_message.json", check=check, ping=ping, body=body)
         payload = json.loads(text)
         self.post(self.channel.slack_webhook_url, json=payload)
 

--- a/templates/integrations/slack_message.json
+++ b/templates/integrations/slack_message.json
@@ -66,7 +66,12 @@
             {"title": "Total Pings",
              "value": "{{ check.n_pings }}",
              "short": true
+            },
+            {% if body %}
+            {"title": "Details",
+            "value": "{{ body|escapejs }}"
             }
+            {% endif %}
         ]
     }]
 }


### PR DESCRIPTION
We were lacking details of failed healthchecks in the slack notification.
This MR extends the template and tries to retrieve the body of the last request.
