### PR TITLE
For email pings, "ping details" dialog box should default to show html if exists, otherwise to plain text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ To set up Healthchecks development environment:
 * Install requirements (Django, ...) into virtualenv:
 
         $ pip install -r healthchecks/requirements.txt
-* Mac OS only - pycurl needs to be reinstalled using the following method (assumes OpenSSL was installed using brew):
+
+* macOS only - pycurl needs to be reinstalled using the following method (assumes OpenSSL was installed using brew):
 
         $ export PYCURL_VERSION=`cat requirements.txt | grep pycurl | cut -d '=' -f3`
         $ export OPENSSL_LOCATION=`brew --prefix openssl`

--- a/templates/front/ping_details.html
+++ b/templates/front/ping_details.html
@@ -85,33 +85,33 @@
         {% else %}
             {% if plain or html %}
             <ul class="nav nav-pills">
-                <li class="active">
+                <li>
                     <a href="#email-body-raw" data-toggle="tab">Raw Message</a>
                 </li>
                 {% if plain %}
-                <li>
+                <li {% if active == 'plain' %} class="active" {% endif %}>
                     <a href="#email-body-plain" data-toggle="tab">Text</a>
                 </li>
                 {% endif %}
                 {% if html %}
-                <li>
+                <li {% if active == 'html' %} class="active" {% endif %}>
                     <a href="#email-body-html" data-toggle="tab">HTML</a>
                 </li>
                 {% endif %}
             </ul>
             <div class="tab-content">
-                <div id="email-body-raw" class="tab-pane active">
+                <div id="email-body-raw" class="tab-pane">
                     <pre>{{ body }}</pre>
                 </div>
 
                 {% if plain %}
-                <div id="email-body-plain" class="tab-pane">
+                <div id="email-body-plain" class="tab-pane{% if active == 'plain' %} active {% endif %}">
                     <pre>{{ plain }}</pre>
                 </div>
                 {% endif %}
 
                 {% if html %}
-                <div id="email-body-html" class="tab-pane">
+                <div id="email-body-html" class="tab-pane {% if active == 'html' %} active {% endif %}">
                     <pre>{{ html }}</pre>
                 </div>
                 {% endif %}


### PR DESCRIPTION
I believe the title says it all.