### PR TITLE
Fix smtpd service without stdin

### DIFF
--- a/hc/api/management/commands/smtpd.py
+++ b/hc/api/management/commands/smtpd.py
@@ -12,6 +12,8 @@ from django.db import connections
 from hc.api.models import Check
 from hc.lib.html import html2text
 
+import time
+
 RE_UUID = re.compile(
     "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
 )
@@ -111,5 +113,10 @@ class Command(BaseCommand):
         controller = Controller(handler, hostname=host, port=port)
         print(f"Starting SMTP listener on {host}:{port} ...")
         controller.start()
-        input("SMTP server running. Press Return to stop server and exit.\n")
+        while True:
+            try:
+                time.sleep(2**32)  # Sleep with a very large timeout
+            except KeyboardInterrupt:
+               print("Interrupt received, exiting.")
+               break
         controller.stop()


### PR DESCRIPTION
Prior to 4b05fc6a8c5687640d30138a48a1403cc54898f4, the smtp daemon was working nicely as a daemon, i.e. without stdin attached (common in service scenarios like systemd). Since that commit, the daemon now relies on stdin being available and actually returning something that is **not** EOF, so you can't attach it to `/dev/null` or similar. You must have a full terminal available to run that as a daemon, which is not what a daemon usually is 😄 

This change removes the dependency on stdin and instead falls back on a more traditional SIGINT behaviour: Run until a SIGINT/CTRL-C is received, then exit.