### PR TITLE
Prevent auto hiding of the nav bar on Mobile Safari

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -10,7 +10,7 @@ body {
 
 .footer {
     position: absolute;
-    bottom: 0;
+    bottom: auto;
     width: 100%;
     /* Set the fixed height of the footer here */
     height: 84px;
@@ -74,6 +74,18 @@ body {
 
 #global-links > li > a {
     font-size: small;
+}
+
+/* see here: https://stackoverflow.com/questions/23164503/disable-hiding-of-address-bar-on-mobile */
+@media only screen and (max-width: 500px) {
+
+    /* prevent auto hiding of the nav bar on mobile safari*/
+    body, html{
+        height: 100%;
+        position: fixed;
+        width: 100%;
+        overflow-y: scroll;
+    }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
This can create situations in which certain buttons (e.g. ping body modal dialog "Got It!" button) appear in an area that is essentially un-clickable. When one clicks in that area, safari raises the nav bar and the underlaying button click does not happen (see attached screen recording as an example trying to click the "Got It!" button, top of the screen was cropped in order to remove potentially sensitive details)

https://github.com/healthchecks/healthchecks/assets/4147381/47ea3089-cc64-4a52-8bd7-3e7cce42ec87

I did check this commit on Safari (macOS 14/iOS 17.0.1), but am not sure how to test this thoroughly across multiple browsers and versions. Would appreciate some help/guidance on this.