### PR TITLE
Update filtering rules to specify that they are case sensitive

### DIFF
--- a/templates/docs/email.html-fragment
+++ b/templates/docs/email.html-fragment
@@ -5,7 +5,10 @@ sending email messages to special email addresses.</p>
 <p>By default, SITE_NAME will consider any email received at the displayed address as
 a "success" signal. You can also configure SITE_NAME to look for specific
 keywords in the subject line or the message body to decide if the message
-is a "start," a "success," or a "failure" signal. You can set up the keywords in
+is a "start," a "success," or a "failure" signal.</p>
+<p>Keywords are case-sensitive and filtered in the following order: SITE_NAME first
+looks for a failure, then success, then start. If filtering is enabled, an email
+containing no keywords will be ignored. You can set up keywords in
 the <strong>Filtering Rules</strong> dialog:</p>
 <p><img alt="Setting filtering rules" src="IMG_URL/filtering_rules.png" /></p>
 <h2>Use Case: Newsletter Delivery Monitoring</h2>

--- a/templates/docs/email.md
+++ b/templates/docs/email.md
@@ -8,7 +8,11 @@ sending email messages to special email addresses.
 By default, SITE_NAME will consider any email received at the displayed address as
 a "success" signal. You can also configure SITE_NAME to look for specific
 keywords in the subject line or the message body to decide if the message
-is a "start," a "success," or a "failure" signal. You can set up the keywords in
+is a "start," a "success," or a "failure" signal.
+
+Keywords are case-sensitive and filtered in the following order: SITE_NAME first
+looks for a failure, then success, then start. If filtering is enabled, an email
+containing no keywords will be ignored. You can set up keywords in
 the **Filtering Rules** dialog:
 
 ![Setting filtering rules](IMG_URL/filtering_rules.png)

--- a/templates/front/filtering_rules_modal.html
+++ b/templates/front/filtering_rules_modal.html
@@ -39,6 +39,7 @@
 
                 <div class="modal-body">
                     <h2>Inbound Emails</h2>
+                    <p>Matching is case-sensitive. <a href="{% url 'hc-serve-doc' 'email' %}">Lean more</a>.</p>
                     <label class="checkbox-container">
                         <input
                             type="checkbox"
@@ -73,7 +74,7 @@
                                 {% if not check.filter_subject and not check.filter_body %}disabled{% endif %}
                                 class="form-control filter-kw" />
                             <span class="help-block">
-                                Comma-separated list of case-sensitive keywords. If subject or body
+                                Comma-separated list of keywords. If subject or body
                                 contains any of the keywords, classify the email as "start".
                             </span>
                         </div>
@@ -92,7 +93,7 @@
                                 {% if not check.filter_subject and not check.filter_body %}disabled{% endif %}
                                 class="form-control filter-kw" />
                             <span class="help-block">
-                                Comma-separated list of case-sensitive keywords. If subject or body
+                                Comma-separated list of keywords. If subject or body
                                 contains any of the keywords, classify the email as "success".
                             </span>
                         </div>
@@ -111,7 +112,7 @@
                                 {% if not check.filter_subject and not check.filter_body %}disabled{% endif %}
                                 class="form-control filter-kw" />
                             <span class="help-block">
-                                Comma-separated list of case-sensitive keywords. If subject or body
+                                Comma-separated list of keywords. If subject or body
                                 contains any of the keywords, classify the email as "failure".
                             </span>
                         </div>

--- a/templates/front/filtering_rules_modal.html
+++ b/templates/front/filtering_rules_modal.html
@@ -73,7 +73,7 @@
                                 {% if not check.filter_subject and not check.filter_body %}disabled{% endif %}
                                 class="form-control filter-kw" />
                             <span class="help-block">
-                                Comma-separated list of keywords. If subject or body
+                                Comma-separated list of case-sensitive keywords. If subject or body
                                 contains any of the keywords, classify the email as "start".
                             </span>
                         </div>
@@ -92,7 +92,7 @@
                                 {% if not check.filter_subject and not check.filter_body %}disabled{% endif %}
                                 class="form-control filter-kw" />
                             <span class="help-block">
-                                Comma-separated list of keywords. If subject or body
+                                Comma-separated list of case-sensitive keywords. If subject or body
                                 contains any of the keywords, classify the email as "success".
                             </span>
                         </div>
@@ -111,7 +111,7 @@
                                 {% if not check.filter_subject and not check.filter_body %}disabled{% endif %}
                                 class="form-control filter-kw" />
                             <span class="help-block">
-                                Comma-separated list of keywords. If subject or body
+                                Comma-separated list of case-sensitive keywords. If subject or body
                                 contains any of the keywords, classify the email as "failure".
                             </span>
                         </div>


### PR DESCRIPTION
We should specify that the keywords are case sensitive - this isn't obvious to the user. I determined this based on my own testing.