### PR TITLE
feat: env var to ignore smtp server certificates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ environment variables:
     EMAIL_USE_TLS = True
     ```
 
+If your SMTP server uses a self-signed certificate (e.g. protonmail-bridge), you can instruct healthchecks to ignore invalid certificates by setting:
+
+  ```python
+  IGNORE_SMTP_SERVER_CERTS = True
+  ```
+
 For more information, have a look at Django documentation,
 [Sending Email](https://docs.djangoproject.com/en/4.2/topics/email/) section.
 

--- a/hc/accounts/backends.py
+++ b/hc/accounts/backends.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import ssl
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.http import HttpRequest
+from django.utils.functional import cached_property
+from django.core.mail.backends.smtp import EmailBackend as DjangoSmtpBackend
 
 from hc.accounts.models import Profile
 from hc.accounts.views import _make_user
@@ -60,6 +64,15 @@ class EmailBackend(BasicBackend):
             return None
 
         return user
+
+
+class EmailBackendIgnoringCerts(DjangoSmtpBackend):
+    @cached_property
+    def ssl_context(self):
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+        return ssl_context
 
 
 class CustomHeaderBackend(BasicBackend):

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -86,6 +86,9 @@ MIDDLEWARE = [
 if envbool("USE_GZIP_MIDDLEWARE", "False"):
     MIDDLEWARE.append("django.middleware.gzip.GZipMiddleware")
 
+if envbool("IGNORE_SMTP_SERVER_CERTS", "False"):
+    EMAIL_BACKEND = 'hc.accounts.backends.EmailBackendIgnoringCerts'
+
 AUTHENTICATION_BACKENDS = [
     "hc.accounts.backends.EmailBackend",
     "hc.accounts.backends.ProfileBackend",


### PR DESCRIPTION
https://github.com/healthchecks/healthchecks/issues/967

Added the possibility to skip server certificate validation with an env var (default False).

Tested running the server locally.
