### PR TITLE
Show warning if apprise is enabled but apprise package is not installed

### DIFF
--- a/hc/api/apps.py
+++ b/hc/api/apps.py
@@ -43,6 +43,29 @@ def settings_check(
 
 
 @register()
+def settings_check(
+    app_configs: Sequence[AppConfig] | None,
+    databases: Sequence[str] | None,
+    **kwargs: dict[str, Any],
+) -> list[Warning]:
+    items = []
+    if settings.APPRISE_ENABLED:
+        try:
+            import apprise
+        except ImportError:
+            items.append(
+                Warning(
+                    "settings.APPRISE_ENABLED is set to True, but apprise is not installed",
+                    hint="try insallting it using pip install apprise",
+                    id="hc.api.W004",
+                )
+            )
+            settings.APPRISE_ENABLED = False
+
+    return items
+
+
+@register()
 def whatsapp_settings_check(
     app_configs: Sequence[AppConfig] | None,
     databases: Sequence[str] | None,

--- a/hc/api/apps.py
+++ b/hc/api/apps.py
@@ -43,7 +43,7 @@ def settings_check(
 
 
 @register()
-def settings_check(
+def apprise_settings_check(
     app_configs: Sequence[AppConfig] | None,
     databases: Sequence[str] | None,
     **kwargs: dict[str, Any],

--- a/hc/api/transports.py
+++ b/hc/api/transports.py
@@ -33,12 +33,6 @@ from hc.lib.typealias import JSONDict, JSONList, JSONValue
 if TYPE_CHECKING:
     from hc.api.models import Channel, Check, Flip, Notification, Ping
 
-try:
-    import apprise
-except ImportError:
-    # Enforce
-    settings.APPRISE_ENABLED = False
-
 logger = logging.getLogger(__name__)
 
 

--- a/hc/api/transports.py
+++ b/hc/api/transports.py
@@ -33,6 +33,12 @@ from hc.lib.typealias import JSONDict, JSONList, JSONValue
 if TYPE_CHECKING:
     from hc.api.models import Channel, Check, Flip, Notification, Ping
 
+try:
+    import apprise
+except ImportError:
+    # Enforce
+    settings.APPRISE_ENABLED = False
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Description
Added  warning message if APPRISE_ENABLED is set to 'True' in settings, and python package 'apprise' is not installed.

Before changes APPRISE_ENABLED was being set to false without warning when apprise was not installed, even if it is enabled in settings.py

## Issue 
Fixes: #1020 

## Checklist
- [ ] Issue Discussed
- [X] self-review
- [X] Format check of changed files with black

## Screenshot

![Screenshot 2024-06-29 122231](https://github.com/healthchecks/healthchecks/assets/22753800/304cf9df-df3c-4ea3-b5a5-b7f8723b2e13)
