### PR TITLE
Fix Trello integration (token regexp too specific)

### DIFF
--- a/hc/front/forms.py
+++ b/hc/front/forms.py
@@ -329,7 +329,7 @@ class AddZulipForm(forms.Form):
 
 
 class AddTrelloForm(forms.Form):
-    token = forms.RegexField(regex=r"^[0-9a-fA-F]{64,256}$")
+    token = forms.CharField(max_length=1000)
     board_name = forms.CharField(max_length=100)
     list_name = forms.CharField(max_length=100)
     list_id = forms.RegexField(regex=r"^[0-9a-fA-F]{16,32}$")

--- a/hc/front/tests/test_add_trello.py
+++ b/hc/front/tests/test_add_trello.py
@@ -34,9 +34,24 @@ class AddTrelloTestCase(BaseTestCase):
         self.assertEqual(c.trello.token, "0" * 64)
         self.assertEqual(c.project, self.project)
 
-    def test_it_handles_256_char_token(self) -> None:
+    def test_it_handles_opaque_token(self) -> None:
+        token = "".join(chr(i) for i in range(1, 128))
         form = {
-            "token": "0" * 256,
+            "token": token,
+            "board_name": "My Board",
+            "list_name": "My List",
+            "list_id": "1" * 32,
+        }
+
+        self.client.login(username="alice@example.org", password="password")
+        elf.client.post(self.url, form)
+
+        c = Channel.objects.get()
+        self.assertEqual(c.trello.token, token)
+
+    def test_it_handles_1000_char_token(self) -> None:
+        form = {
+            "token": "0" * 1000,
             "board_name": "My Board",
             "list_name": "My List",
             "list_id": "1" * 32,
@@ -46,7 +61,7 @@ class AddTrelloTestCase(BaseTestCase):
         self.client.post(self.url, form)
 
         c = Channel.objects.get()
-        self.assertEqual(c.trello.token, "0" * 256)
+        self.assertEqual(c.trello.token, "0" * 1000)
 
     @override_settings(TRELLO_APP_KEY=None)
     def test_it_requires_trello_app_key(self) -> None:


### PR DESCRIPTION
When creating Trello integration I got 400 after selecting the board to put notifications into.

It turns out the token I got from Trello does not match the regular expression as it has the following format:
"ATTA" + 64 hex chars (lowercase) + 8 hex chars (uppercase)

That "ATTA" prefix does not match `^[0-9a-fA-F]{64,256}$`. Just in case I changed the range from `a-fA-F` to `a-zA-Z` and added `_` and `-` (all base64 url-safe characters).