### PR TITLE
Fix allow rid variable to be upper and lowercase

### DIFF
--- a/hc/lib/string.py
+++ b/hc/lib/string.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 
 uuid_match_regex = re.compile(
-    "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE
 )
 
 


### PR DESCRIPTION
Shell scripts with healthchecks to measure execution time using 'rid' were failing on my MacOS (they were created in uppercase instead of lowercase). 

With this patch healthcheck now supports 'rid' created with /usr/bin/uuidgen on MacOS. 
The uuid.UUID module in python interpret lower and upper case uuids , only the validation in 'hc/lib/string.py' was restricted to only lowercase.

Now it supports both ;-)