### PR TITLE
Add prefixes to API keys. Closes #1148

### DIFF
--- a/hc/accounts/tests/test_project.py
+++ b/hc/accounts/tests/test_project.py
@@ -65,8 +65,8 @@ class ProjectTestCase(BaseTestCase):
         self.assertEqual(r.status_code, 200)
 
         self.project.refresh_from_db()
-        self.assertTrue(self.project.api_key_readonly.startswith('RO_'))
-        self.assertEqual(len(self.project.api_key_readonly), 3 + 32)
+        self.assertTrue(self.project.api_key_readonly.startswith('hcr_'))
+        self.assertEqual(len(self.project.api_key_readonly), 32)
         self.assertFalse("b'" in self.project.api_key_readonly)
 
     def test_it_requires_rw_access_to_create_key(self) -> None:

--- a/hc/accounts/tests/test_project.py
+++ b/hc/accounts/tests/test_project.py
@@ -65,7 +65,8 @@ class ProjectTestCase(BaseTestCase):
         self.assertEqual(r.status_code, 200)
 
         self.project.refresh_from_db()
-        self.assertEqual(len(self.project.api_key_readonly), 32)
+        self.assertTrue(self.project.api_key_readonly.startswith('RO_'))
+        self.assertEqual(len(self.project.api_key_readonly), 3 + 32)
         self.assertFalse("b'" in self.project.api_key_readonly)
 
     def test_it_requires_rw_access_to_create_key(self) -> None:

--- a/hc/accounts/views.py
+++ b/hc/accounts/views.py
@@ -150,12 +150,8 @@ def _check_2fa(request: HttpRequest, user: User) -> HttpResponse:
     return _redirect_after_login(request)
 
 
-def _new_key(len: int = 32, prefix: str = "") -> str:
-    key = ''.join(secrets.choice(ALPHABET) for i in range(len))
-    if prefix:
-        return prefix + "_" + key
-    else:
-        return key
+def _new_key(nbytes: int = 32, prefix: str = "") -> str:
+    return prefix + ''.join(secrets.choice(ALPHABET) for i in range(nbytes - len(prefix)))
 
 
 def _set_autologin_cookie(response: HttpResponse) -> None:
@@ -387,9 +383,9 @@ def project(request: AuthenticatedHttpRequest, code: UUID) -> HttpResponse:
                 return HttpResponseForbidden()
 
             if request.POST["create_key"] == "api_key":
-                project.api_key = _new_key(28, "hcw")  #28 + 4 = 32
+                project.api_key = _new_key(32, "hcw_")
             elif request.POST["create_key"] == "api_key_readonly":
-                project.api_key_readonly = _new_key(28, "hcr")  #28 + 4 = 32
+                project.api_key_readonly = _new_key(32, "hcr_")
             elif request.POST["create_key"] == "ping_key":
                 project.ping_key = _new_key(22)
             project.save()

--- a/hc/accounts/views.py
+++ b/hc/accounts/views.py
@@ -147,11 +147,14 @@ def _check_2fa(request: HttpRequest, user: User) -> HttpResponse:
     return _redirect_after_login(request)
 
 
-def _new_key(nbytes: int = 24) -> str:
+def _new_key(nbytes: int = 24, prefix: str = "") -> str:
     while True:
         candidate = token_urlsafe(nbytes)
-        if candidate[0] not in "-_" and candidate[-1] not in "-_":
-            return candidate
+        if candidate[-1] not in "-_":
+            if prefix:
+                return prefix + "_" +candidate
+            elif candidate[0] not in "-_":
+                return candidate
 
 
 def _set_autologin_cookie(response: HttpResponse) -> None:
@@ -383,9 +386,9 @@ def project(request: AuthenticatedHttpRequest, code: UUID) -> HttpResponse:
                 return HttpResponseForbidden()
 
             if request.POST["create_key"] == "api_key":
-                project.api_key = _new_key(24)
+                project.api_key = _new_key(24, "RW")
             elif request.POST["create_key"] == "api_key_readonly":
-                project.api_key_readonly = _new_key(24)
+                project.api_key_readonly = _new_key(24, "RO")
             elif request.POST["create_key"] == "ping_key":
                 project.ping_key = _new_key(16)
             project.save()


### PR DESCRIPTION
- Added "RW_" prefix to write-enabled API keys for clear identification
- Added "RO_" prefix to read-only API keys
- Fixed test_it_creates_readonly_key