### PR TITLE
Store API keys in the database in hashed form

### DIFF
--- a/hc/accounts/models.py
+++ b/hc/accounts/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import random
 import uuid
 from datetime import date, datetime
@@ -465,6 +466,44 @@ class Project(models.Model):
 
     def get_absolute_url(self) -> str:
         return reverse("hc-checks", args=[self.code])
+
+    def _make_api_key(self, prefix: str) -> tuple[str, str]:
+        """Generate an API key with specified prefix, return (key, key_hash) tuple.
+
+        * `key` is what will be presented to the user,
+        * `key_hash` will be stored in the database.
+
+        `key_hash` consists of two parts:
+        * first 8 characters: the first 8 characters of plain text key
+          (for efficiently looking up project in the database by its API key)
+        * next 64 characters: HMAC(SECRET_KEY, key)
+        """
+        while True:
+            secret = token_urlsafe(21)
+            if "-" not in secret and "_" not in secret:
+                break
+
+        key = f"{prefix}{secret}"
+        digest = hmac.digest(settings.SECRET_KEY.encode(), key.encode(), "sha256")
+        return key, secret[:8] + digest.hex()
+
+    def set_api_key(self) -> str:
+        key, key_hash = self._make_api_key("hcw_")
+        self.api_key = key_hash
+        return key
+
+    def set_api_key_readonly(self) -> str:
+        key, key_hash = self._make_api_key("hcr_")
+        self.api_key_readonly = key_hash
+        return key
+
+    def compare_api_key(self, key: str) -> bool:
+        digest = hmac.digest(settings.SECRET_KEY.encode(), key.encode(), "sha256")
+        if key.startswith("hcr_"):
+            expected = self.api_key_readonly[8:]
+        else:
+            expected = self.api_key[8:]
+        return hmac.compare_digest(digest.hex(), expected)
 
 
 class Member(models.Model):

--- a/hc/accounts/tests/test_project.py
+++ b/hc/accounts/tests/test_project.py
@@ -65,7 +65,7 @@ class ProjectTestCase(BaseTestCase):
         self.assertEqual(r.status_code, 200)
 
         self.project.refresh_from_db()
-        self.assertEqual(len(self.project.api_key_readonly), 32)
+        self.assertEqual(len(self.project.api_key_readonly), 72)
         self.assertFalse("b'" in self.project.api_key_readonly)
 
     def test_it_requires_rw_access_to_create_key(self) -> None:

--- a/hc/accounts/views.py
+++ b/hc/accounts/views.py
@@ -383,9 +383,9 @@ def project(request: AuthenticatedHttpRequest, code: UUID) -> HttpResponse:
                 return HttpResponseForbidden()
 
             if request.POST["create_key"] == "api_key":
-                project.api_key = _new_key(24)
+                ctx["new_key"] = project.set_api_key()
             elif request.POST["create_key"] == "api_key_readonly":
-                project.api_key_readonly = _new_key(24)
+                ctx["new_key"] = project.set_api_key_readonly()
             elif request.POST["create_key"] == "ping_key":
                 project.ping_key = _new_key(16)
             project.save()

--- a/hc/api/decorators.py
+++ b/hc/api/decorators.py
@@ -30,6 +30,44 @@ def _get_api_version(request: HttpRequest) -> int:
     return 1
 
 
+def lookup_project(api_key: str, require_rw: bool) -> Project | None:
+    """Look up project by API key.
+
+    This handles both the old plain text API keys, and the new hashed API keys.
+    For the hashed API keys, it looks up project by the first 8 characters of the
+    random part of the key, then calls Project.compare_api_key().
+    """
+
+    # Hashed keys
+    if api_key.startswith("hcw_"):
+        secret8 = api_key[4:12]
+        for project in Project.objects.filter(api_key__startswith=secret8):
+            if project.compare_api_key(api_key):
+                return project
+
+    if not require_rw and api_key.startswith("hcr_"):
+        secret8 = api_key[4:12]
+        for project in Project.objects.filter(api_key_readonly__startswith=secret8):
+            if project.compare_api_key(api_key):
+                return project
+
+    # Plain text keys
+    if require_rw:
+        try:
+            return Project.objects.get(api_key=api_key)
+        except Project.DoesNotExist:
+            pass
+    else:
+        write_key_match = Q(api_key=api_key)
+        read_key_match = Q(api_key_readonly=api_key)
+        try:
+            return Project.objects.get(write_key_match | read_key_match)
+        except Project.DoesNotExist:
+            pass
+
+    return None
+
+
 def authorize(f: ViewFunc) -> ViewFunc:
     @wraps(f)
     def wrapper(request: ApiRequest, *args: Any, **kwds: Any) -> HttpResponse:
@@ -56,9 +94,8 @@ def authorize(f: ViewFunc) -> ViewFunc:
         if len(api_key) != 32:
             return error("missing api key", 401)
 
-        try:
-            request.project = Project.objects.get(api_key=api_key)
-        except Project.DoesNotExist:
+        request.project = lookup_project(api_key, require_rw=True)
+        if request.project is None:
             return error("wrong api key", 401)
 
         request.readonly = False
@@ -79,14 +116,13 @@ def authorize_read(f: ViewFunc) -> ViewFunc:
         if len(api_key) != 32:
             return error("missing api key", 401)
 
-        write_key_match = Q(api_key=api_key)
-        read_key_match = Q(api_key_readonly=api_key)
-        try:
-            request.project = Project.objects.get(write_key_match | read_key_match)
-        except Project.DoesNotExist:
+        request.project = lookup_project(api_key, require_rw=False)
+        if request.project is None:
             return error("wrong api key", 401)
 
-        request.readonly = api_key == request.project.api_key_readonly
+        request.readonly = (
+            api_key.startswith("hcr_") or api_key == request.project.api_key_readonly
+        )
         request.v = _get_api_version(request)
         return f(request, *args, **kwds)
 

--- a/static/js/project.js
+++ b/static/js/project.js
@@ -1,22 +1,23 @@
-$(function() {
+$(function () {
+    $("#key-created-modal").modal("show");
 
-    $(".member-remove").click(function() {
+    $(".member-remove").click(function () {
         $("#rtm-email").text(this.dataset.email);
         $("#remove-team-member-email").val(this.dataset.email);
-        $('#remove-team-member-modal').modal("show");
+        $("#remove-team-member-modal").modal("show");
 
         return false;
     });
 
-    $('#invite-team-member-modal').on('shown.bs.modal', function () {
-        $('#itm-email').focus();
-    })
+    $("#invite-team-member-modal").on("shown.bs.modal", function () {
+        $("#itm-email").focus();
+    });
 
-    $('#set-project-name-modal').on('shown.bs.modal', function () {
-        $('#project-name').focus();
-    })
+    $("#set-project-name-modal").on("shown.bs.modal", function () {
+        $("#project-name").focus();
+    });
 
-    $(".add-to-team").click(function() {
+    $(".add-to-team").click(function () {
         $("#itm-email").val(this.dataset.email);
         $("#itm-email-display").text(this.dataset.email);
         $("#invite-team-member-modal").modal("show");
@@ -25,20 +26,18 @@ $(function() {
 
     // Enable the submit button in transfer form when user selects
     // the target owner:
-    $("#new-owner").on("change", function() {
+    $("#new-owner").on("change", function () {
         $("#transfer-confirm").prop("disabled", !this.value);
     });
 
-    $("a[data-revoke-key]").click(function() {
+    $("a[data-revoke-key]").click(function () {
         $("#revoke-key-type").val(this.dataset.revokeKey);
         $("#revoke-key-modal .name").text(this.dataset.name);
         $("#revoke-key-modal").modal("show");
-    })
+    });
 
-    $("a[data-create-key]").click(function() {
+    $("a[data-create-key]").click(function () {
         $("#create-key-type").val(this.dataset.createKey);
         $("#create-key-form").submit();
-    })
-
-
+    });
 });

--- a/templates/accounts/project.html
+++ b/templates/accounts/project.html
@@ -83,7 +83,9 @@
                     <tr>
                         <td>API key</td>
                         <td>
-                            {% if project.api_key %}
+                            {% if project.api_key|length == 72 %}
+                                <code>hcw_****************************</code>
+                            {% elif project.api_key %}
                             {% if show_keys %}
                                 <code>{{ project.api_key }}</code>
                             {% else %}
@@ -106,7 +108,9 @@
                     <tr>
                         <td>API key (read-only)</td>
                         <td>
-                            {% if project.api_key_readonly %}
+                            {% if project.api_key_readonly|length == 72 %}
+                                <code>hcr_****************************</code>
+                            {% elif project.api_key_readonly %}
                             {% if show_keys %}
                                 <code>{{ project.api_key_readonly }}</code>
                             {% else %}
@@ -638,6 +642,27 @@
     </div>
 </div>
 {% endif %}
+
+{% if new_key %}
+<div id="key-created-modal" class="modal">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4>API Key Created!</h4>
+            </div>
+            <div class="modal-body">
+                <p>Copy the key and store it securely. The key will not be shown again:</p>
+                <input type="text" class="form-control" value="{{ new_key }}" readonly />
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">OK, I copied the key</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+
 
 {% endwith %}
 {% endblock %}


### PR DESCRIPTION
Currently API keys are stored in in plain text in the database. 

The PR implements storing future API keys in a hashed form (the existing plain text API keys still work as before).

The format of the keys presented to the user:

* Read-write keys: `hcw_sO9zU1olGylct7RMyUAkDaPMFHgx` (prefix `hcw_` followed by 28 random characters)
* Read-only keys: `hcr_ZJz50yB761pJ0do1YOe56Iofng76` (prefix `hcr_` followed by 28 random characters)

The format of the keys stored in the database:

```
[first 8 plain text characters of the API key][64 characters of HMAC of the API key]
```

The value stored in the database includes first 8 plaintext characters of the key for the purpose of being able to efficiently look up a project by its API key – 

```
Project.objects.filter(api_key__startswith=key_from_client[:8])
```

HMAC is calculated using python's hmac module:

```
hmac.digest(SECRET_KEY.encode(), api_key.encode(), "sha256")
```

Since the API keys (excluding the first 8 characters) are now stored in a hashed form, we can only show them to the user right after they are generated. The user will no longer be able to see their API keys in the Project Settings page at a later time.
