### PR TITLE
Allow setting up superuser with command parameters

### DIFF
--- a/hc/accounts/management/commands/createsuperuser.py
+++ b/hc/accounts/management/commands/createsuperuser.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from getpass import getpass
 from typing import Any
 
@@ -15,10 +17,10 @@ class Command(BaseCommand):
     help = """Create a super-user account."""
 
     def handle(self, **options: Any) -> str:
-        email = None
-        password = None
+        email = os.getenv("SUPERUSER_EMAIL")
+        password = os.getenv("SUPERUSER_PASSWORD")
 
-        while not email:
+        while email is None:
             raw = input("Email address:")
             try:
                 email = LowercaseEmailField().clean(raw)
@@ -30,7 +32,7 @@ class Command(BaseCommand):
                 email = None
                 continue
 
-        while not password:
+        while password is None:
             p1 = getpass()
             p2 = getpass("Password (again):")
             if p1.strip() == "":

--- a/hc/accounts/management/commands/createsuperuser.py
+++ b/hc/accounts/management/commands/createsuperuser.py
@@ -46,30 +46,32 @@ class Command(BaseCommand):
 
         if email is not None:
             email = self.validate_email(email)
-            if email is None:
-                self.stderr.write("Invalid email argument.")
-                sys.exit(2)
 
         if password is not None:
             password = self.validate_password(password)
-            if password is None:
-                self.stderr.write("Invalid password argument.")
-                sys.exit(2)
 
-        while email is None:
-            raw = input("Email address:")
-            email = self.validate_email(raw)
+        if sys.stdin.isatty():
+            while email is None:
+                raw = input("Email address:")
+                email = self.validate_email(raw)
+        elif email is None:
+            self.stderr.write("Missing or invalid required argument: --email")
+            sys.exit(2)
 
-        while password is None:
-            p1 = getpass()
-            p2 = getpass("Password (again):")
+        if sys.stdin.isatty():
+            while password is None:
+                p1 = getpass()
+                p2 = getpass("Password (again):")
 
-            if p1 != p2:
-                self.stderr.write("Error: Your passwords didn't match.")
-                password = None
-                continue
+                if p1 != p2:
+                    self.stderr.write("Error: Your passwords didn't match.")
+                    password = None
+                    continue
 
-            password = self.validate_password(p1)
+                password = self.validate_password(p1)
+        elif password is None:
+            self.stderr.write("Missing or invalid required argument: --password/--pass")
+            sys.exit(2)
 
         user = _make_user(email)
         user.set_password(password)

--- a/hc/accounts/management/commands/createsuperuser.py
+++ b/hc/accounts/management/commands/createsuperuser.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         return password
 
     def add_arguments(self, parser):
-        parser.add_argument("--email", type=str, )
+        parser.add_argument("--email", type=str)
         parser.add_argument("--password", "--pass", type=str)
 
     def handle(self, **options: Any) -> str:

--- a/hc/accounts/management/commands/createsuperuser.py
+++ b/hc/accounts/management/commands/createsuperuser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import sys
 
 from getpass import getpass
 from typing import Any
@@ -46,8 +46,15 @@ class Command(BaseCommand):
 
         if email is not None:
             email = self.validate_email(email)
+            if email is None:
+                self.stderr.write("Invalid email argument.")
+                sys.exit(2)
+
         if password is not None:
             password = self.validate_password(password)
+            if password is None:
+                self.stderr.write("Invalid password argument.")
+                sys.exit(2)
 
         while email is None:
             raw = input("Email address:")

--- a/templates/docs/self_hosted.md
+++ b/templates/docs/self_hosted.md
@@ -83,6 +83,8 @@ To access the administration panel, if you haven't already, create a superuser a
 
     $ ./manage.py createsuperuser
 
+*The command can be run non-interactively by setting the `SUPERUSER_EMAIL` and `SUPERUSER_PASSWORD` environment variables beforehand.*
+
 Then, log into the site using the superuser credentials. Once logged in,
 click on the "Account" dropdown in top navigation, and select "Site Administration".
 

--- a/templates/docs/self_hosted.md
+++ b/templates/docs/self_hosted.md
@@ -68,7 +68,6 @@ The following instructions assume you are using a Debian-based OS.
 
 * From another shell, run the `sendalerts` management command, responsible for
   sending out notifications:
-
         $ ./manage.py sendalerts
 
 At this point, the site should now be running at `http://localhost:8000`.
@@ -83,7 +82,11 @@ To access the administration panel, if you haven't already, create a superuser a
 
     $ ./manage.py createsuperuser
 
-*The command can be run non-interactively by setting the `SUPERUSER_EMAIL` and `SUPERUSER_PASSWORD` environment variables beforehand.*
+This will trigger an interactive prompt.
+
+You can also provide credentials via parameters, bypassing the interactive prompt:
+
+    $ ./manage.py createsuperuser --email user@example.com --password changeme123
 
 Then, log into the site using the superuser credentials. Once logged in,
 click on the "Account" dropdown in top navigation, and select "Site Administration".

--- a/templates/docs/self_hosted_docker.md
+++ b/templates/docs/self_hosted_docker.md
@@ -33,6 +33,8 @@ termination.
 
         $ docker-compose run web /opt/healthchecks/manage.py createsuperuser
 
+  *The command can be run non-interactively by setting the `SUPERUSER_EMAIL` and `SUPERUSER_PASSWORD` environment variables beforehand.*
+
 * Open [http://localhost:8000](http://localhost:8000) in your browser and log in with
   the credentials from the previous step.
 

--- a/templates/docs/self_hosted_docker.md
+++ b/templates/docs/self_hosted_docker.md
@@ -33,7 +33,11 @@ termination.
 
         $ docker-compose run web /opt/healthchecks/manage.py createsuperuser
 
-  *The command can be run non-interactively by setting the `SUPERUSER_EMAIL` and `SUPERUSER_PASSWORD` environment variables beforehand.*
+    This will trigger an interactive prompt.
+
+    You can also provide credentials via parameters, bypassing the interactive prompt:
+
+        $ docker compose run web /opt/healthchecks/manage.py createsuperuser --email user@example.com --password changeme123
 
 * Open [http://localhost:8000](http://localhost:8000) in your browser and log in with
   the credentials from the previous step.


### PR DESCRIPTION
Useful where multiple instances are deployed via CI/CD pipelines, superuser credentials can be passed down from pipeline secrets, automatically creating the superuser after deployment. Removes one more manual configuration step.

It would go something like this for docker-based deployments: 
```
docker-compose run -e SUPERUSER_EMAIL=test@mail.com -e SUPERUSER_PASSWORD=test123 web /opt/healthchecks/manage.py createsuperuser
````
or for local/development:

```
SUPERUSER_EMAIL=test@mail.com -e SUPERUSER_PASSWORD=test123 ./manage.py createsuperuser
```
