### PR TITLE
Make sure the cell is added as well for months when the check did not exist.

### DIFF
--- a/templates/emails/report-body-text.html
+++ b/templates/emails/report-body-text.html
@@ -26,7 +26,7 @@ Project "{{ group.grouper|safe }}"
 {{ d.duration|hc_approx_duration }} total{% endcell%}
                 {% else %}
                     {% if d.no_data %}
-                        {% comment %} The check didn't exist yet {% endcomment %}
+                        {% cell %}{% comment %} The check didn't exist yet {% endcomment %}{% endcell %}
                     {% else %}
                         {% cell %}All good!{% endcell %}
                     {% endif %}


### PR DESCRIPTION
Fixes #1236

The HTML version https://github.com/healthchecks/healthchecks/blob/5e274e6aebf71fa69f83cd29fadf10fb40fba7a2/templates/emails/report-summary-html.html#L75-L81 has the `<td>` ... `</td>` around the whole `if` ... `endif`. I can do the same here as well, I'm just concerned that might bring some whitespace that would be problematic in the text output -- that's why the initial proposal is to just duplicate the `cell`.
