### PR TITLE
Add API endpoint to clear a check's events

### DIFF
--- a/hc/api/tests/test_clear_events.py
+++ b/hc/api/tests/test_clear_events.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import timedelta as td
+
+from django.utils.timezone import now
+
+from hc.api.models import Channel, Check, Flip, Notification, Ping
+from hc.test import BaseTestCase
+
+
+class ClearEventsTestCase(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.check = Check.objects.create(project=self.project, status="down")
+        self.check.last_ping = now()
+        self.check.last_start = now()
+        self.check.last_duration = td(seconds=5)
+        self.check.has_confirmation_link = True
+        self.check.alert_after = now()
+        self.check.save()
+
+        Ping.objects.create(owner=self.check, n=1)
+        channel = Channel.objects.create(project=self.project, kind="email")
+        Notification.objects.create(
+            owner=self.check, channel=channel, check_status="down"
+        )
+        Flip.objects.create(owner=self.check, created=now(), old_status="up", new_status="down")
+
+        self.url = f"/api/v3/checks/{self.check.code}/events/clear"
+
+    def test_it_works(self) -> None:
+        r = self.csrf_client.post(
+            self.url, "", content_type="application/json", HTTP_X_API_KEY="X" * 32
+        )
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r["Access-Control-Allow-Origin"], "*")
+
+        self.check.refresh_from_db()
+        self.assertEqual(self.check.status, "new")
+        self.assertIsNone(self.check.last_ping)
+        self.assertIsNone(self.check.last_start)
+        self.assertIsNone(self.check.last_duration)
+        self.assertFalse(self.check.has_confirmation_link)
+        self.assertIsNone(self.check.alert_after)
+
+        self.assertFalse(self.check.ping_set.exists())
+        self.assertFalse(self.check.notification_set.exists())
+        self.assertFalse(self.check.flip_set.exists())
+
+    def test_it_accepts_api_key_in_post_body(self) -> None:
+        payload = {"api_key": "X" * 32}
+        r = self.csrf_client.post(self.url, payload, content_type="application/json")
+        self.assertEqual(r.status_code, 200)
+
+    def test_it_handles_options(self) -> None:
+        r = self.client.options(self.url)
+        self.assertEqual(r.status_code, 204)
+        self.assertIn("POST", r["Access-Control-Allow-Methods"])
+
+    def test_it_only_allows_post(self) -> None:
+        r = self.client.get(self.url, HTTP_X_API_KEY="X" * 32)
+        self.assertEqual(r.status_code, 405)
+
+    def test_it_validates_ownership(self) -> None:
+        check = Check.objects.create(project=self.bobs_project, status="down")
+        url = f"/api/v3/checks/{check.code}/events/clear"
+        r = self.client.post(
+            url, "", content_type="application/json", HTTP_X_API_KEY="X" * 32
+        )
+        self.assertEqual(r.status_code, 403)
+
+    def test_it_validates_uuid(self) -> None:
+        url = "/api/v3/checks/not-uuid/events/clear"
+        r = self.client.post(
+            url, "", content_type="application/json", HTTP_X_API_KEY="X" * 32
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_it_handles_missing_check(self) -> None:
+        url = "/api/v3/checks/07c2f548-9850-4b27-af5d-6c9dc157ec02/events/clear"
+        r = self.client.post(
+            url, "", content_type="application/json", HTTP_X_API_KEY="X" * 32
+        )
+        self.assertEqual(r.status_code, 404)
+
+    def test_it_rejects_non_dict_post_body(self) -> None:
+        r = self.csrf_client.post(self.url, "123", content_type="application/json")
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(
+            r.json()["error"], "json validation error: value is not an object"
+        )

--- a/hc/api/urls.py
+++ b/hc/api/urls.py
@@ -52,6 +52,11 @@ api_urls = [
     path("checks/<uuid:code>/pause", views.pause, name="hc-api-pause"),
     path("checks/<uuid:code>/resume", views.resume, name="hc-api-resume"),
     path(
+        "checks/<uuid:code>/events/clear",
+        views.clear_events,
+        name="hc-api-clear-events",
+    ),
+    path(
         "notifications/<uuid:code>/status",
         views.notification_status,
         name="hc-api-notification-status",

--- a/templates/docs/api.html-fragment
+++ b/templates/docs/api.html-fragment
@@ -47,6 +47,10 @@ in your account.</p>
 <td><code>POST SITE_ROOT/api/v3/checks/&lt;uuid&gt;/resume</code></td>
 </tr>
 <tr>
+<td><a href="#clear-check-events">Clear a check's events</a></td>
+<td><code>POST SITE_ROOT/api/v3/checks/&lt;uuid&gt;/events/clear</code></td>
+</tr>
+<tr>
 <td><a href="#delete-check">Delete check</a></td>
 <td><code>DELETE SITE_ROOT/api/v3/checks/&lt;uuid&gt;</code></td>
 </tr>
@@ -995,6 +999,64 @@ configuration parameter set to <code>True</code>.</p>
 </dl>
 <h3>Example Request</h3>
 <div class="highlight"><pre><span></span><code>curl<span class="w"> </span>SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume<span class="w"> </span><span class="se">\</span>
+<span class="w">    </span>--request<span class="w"> </span>POST<span class="w"> </span>--header<span class="w"> </span><span class="s2">&quot;X-Api-Key: your-api-key&quot;</span><span class="w"> </span>--data<span class="w"> </span><span class="s2">&quot;&quot;</span>
+</code></pre></div>
+
+<p>Note: the <code>--data ""</code> argument forces curl to send a <code>Content-Length</code> request header
+even though the request body is empty. For HTTP POST requests, the <code>Content-Length</code>
+header is sometimes required by some network proxies and web servers.</p>
+<h3>Example Response</h3>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Backups&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;slug&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;tags&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;prod www&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;desc&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;grace&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">60</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;n_pings&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;status&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;new&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;started&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;last_ping&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;next_ping&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;manual_resume&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;methods&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;subject&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;subject_fail&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;start_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;success_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;failure_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_subject&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_body&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_http_body&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_default_fail&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;badge_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/b/2/d43c84db-1502-4d86-a89d-181a33e25896.svg&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;uuid&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;ping_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;PING_ENDPOINT7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;update_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;pause_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/pause&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;resume_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;channels&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;timeout&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">3600</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<h2 class="rule" id="clear-check-events">Clear a Check's Events</h2>
+<p><code>POST SITE_ROOT/api/v3/checks/&lt;uuid&gt;/events/clear</code></p>
+<p>Clears all logged events for a check. This resets the check's state and deletes
+associated pings, notifications, and status changes.</p>
+<p>This API call has no request parameters.</p>
+<h3>Response Codes</h3>
+<dl>
+<dt>200 OK</dt>
+<dd>The events were successfully cleared.</dd>
+<dt>401 Unauthorized</dt>
+<dd>The API key is either missing or invalid.</dd>
+<dt>403 Forbidden</dt>
+<dd>Access denied, wrong API key.</dd>
+<dt>404 Not Found</dt>
+<dd>The specified check does not exist.</dd>
+</dl>
+<h3>Example Request</h3>
+<div class="highlight"><pre><span></span><code>curl<span class="w"> </span>SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/events/clear<span class="w"> </span><span class="se">\</span>
 <span class="w">    </span>--request<span class="w"> </span>POST<span class="w"> </span>--header<span class="w"> </span><span class="s2">&quot;X-Api-Key: your-api-key&quot;</span><span class="w"> </span>--data<span class="w"> </span><span class="s2">&quot;&quot;</span>
 </code></pre></div>
 

--- a/templates/docs/api.md
+++ b/templates/docs/api.md
@@ -23,6 +23,7 @@ Endpoint Name                                         | Endpoint Address
 [Update an existing check](#update-check)             | `POST SITE_ROOT/api/v3/checks/<uuid>`
 [Pause monitoring of a check](#pause-check)           | `POST SITE_ROOT/api/v3/checks/<uuid>/pause`
 [Resume monitoring of a check](#resume-check)         | `POST SITE_ROOT/api/v3/checks/<uuid>/resume`
+[Clear a check's events](#clear-check-events)          | `POST SITE_ROOT/api/v3/checks/<uuid>/events/clear`
 [Delete check](#delete-check)                         | `DELETE SITE_ROOT/api/v3/checks/<uuid>`
 **Pings**                                             |
 [List check's logged pings](#list-pings)              | `GET SITE_ROOT/api/v3/checks/<uuid>/pings/`
@@ -1119,6 +1120,77 @@ This API call has no request parameters.
 
 ```bash
 curl SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume \
+    --request POST --header "X-Api-Key: your-api-key" --data ""
+```
+
+Note: the `--data ""` argument forces curl to send a `Content-Length` request header
+even though the request body is empty. For HTTP POST requests, the `Content-Length`
+header is sometimes required by some network proxies and web servers.
+
+### Example Response
+
+```json
+{
+  "name": "Backups",
+  "slug": "",
+  "tags": "prod www",
+  "desc": "",
+  "grace": 60,
+  "n_pings": 0,
+  "status": "new",
+  "started": false,
+  "last_ping": null,
+  "next_ping": null,
+  "manual_resume": false,
+  "methods": "",
+  "subject": "",
+  "subject_fail": "",
+  "start_kw": "",
+  "success_kw": "",
+  "failure_kw": "",
+  "filter_subject": false,
+  "filter_body": false,
+  "filter_http_body": false,
+  "filter_default_fail": false,
+  "badge_url": "SITE_ROOT/b/2/d43c84db-1502-4d86-a89d-181a33e25896.svg",
+  "uuid": "7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "ping_url": "PING_ENDPOINT7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "update_url": "SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "pause_url": "SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/pause",
+  "resume_url": "SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume",
+  "channels": "",
+  "timeout": 3600
+}
+```
+
+
+## Clear a Check's Events {: #clear-check-events .rule }
+
+`POST SITE_ROOT/api/v3/checks/<uuid>/events/clear`
+
+Clears all logged events for a check. This resets the check's state and deletes
+associated pings, notifications, and status changes.
+
+This API call has no request parameters.
+
+### Response Codes
+
+200 OK
+:   The events were successfully cleared.
+
+401 Unauthorized
+:   The API key is either missing or invalid.
+
+403 Forbidden
+:   Access denied, wrong API key.
+
+404 Not Found
+:   The specified check does not exist.
+
+### Example Request
+
+```bash
+curl SITE_ROOT/api/v3/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/events/clear \
     --request POST --header "X-Api-Key: your-api-key" --data ""
 ```
 

--- a/templates/docs/apiv1.html-fragment
+++ b/templates/docs/apiv1.html-fragment
@@ -47,6 +47,10 @@ in your account.</p>
 <td><code>POST SITE_ROOT/api/v1/checks/&lt;uuid&gt;/resume</code></td>
 </tr>
 <tr>
+<td><a href="#clear-check-events">Clear a check's events</a></td>
+<td><code>POST SITE_ROOT/api/v1/checks/&lt;uuid&gt;/events/clear</code></td>
+</tr>
+<tr>
 <td><a href="#delete-check">Delete check</a></td>
 <td><code>DELETE SITE_ROOT/api/v1/checks/&lt;uuid&gt;</code></td>
 </tr>
@@ -931,6 +935,64 @@ header is sometimes required by some network proxies and web servers.</p>
 <span class="w">  </span><span class="nt">&quot;tags&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;prod www&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;timeout&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">3600</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;update_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v1/checks/f618072a-7bde-4eee-af63-71a77c5723bc&quot;</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<h2 class="rule" id="clear-check-events">Clear a Check's Events</h2>
+<p><code>POST SITE_ROOT/api/v1/checks/&lt;uuid&gt;/events/clear</code></p>
+<p>Clears all logged events for a check. This resets the check's state and deletes
+associated pings, notifications, and status changes.</p>
+<p>This API call has no request parameters.</p>
+<h3>Response Codes</h3>
+<dl>
+<dt>200 OK</dt>
+<dd>The events were successfully cleared.</dd>
+<dt>401 Unauthorized</dt>
+<dd>The API key is either missing or invalid.</dd>
+<dt>403 Forbidden</dt>
+<dd>Access denied, wrong API key.</dd>
+<dt>404 Not Found</dt>
+<dd>The specified check does not exist.</dd>
+</dl>
+<h3>Example Request</h3>
+<div class="highlight"><pre><span></span><code>curl<span class="w"> </span>SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/events/clear<span class="w"> </span><span class="se">\</span>
+<span class="w">    </span>--request<span class="w"> </span>POST<span class="w"> </span>--header<span class="w"> </span><span class="s2">&quot;X-Api-Key: your-api-key&quot;</span><span class="w"> </span>--data<span class="w"> </span><span class="s2">&quot;&quot;</span>
+</code></pre></div>
+
+<p>Note: the <code>--data ""</code> argument forces curl to send a <code>Content-Length</code> request header
+even though the request body is empty. For HTTP POST requests, the <code>Content-Length</code>
+header is sometimes required by some network proxies and web servers.</p>
+<h3>Example Response</h3>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Backups&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;slug&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;tags&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;prod www&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;desc&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;grace&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">60</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;n_pings&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;status&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;new&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;started&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;last_ping&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;next_ping&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;manual_resume&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;methods&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;subject&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;subject_fail&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;start_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;success_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;failure_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_subject&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_body&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_http_body&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_default_fail&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;badge_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/b/2/d43c84db-1502-4d86-a89d-181a33e25896.svg&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;uuid&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;ping_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;PING_ENDPOINT7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;update_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;pause_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/pause&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;resume_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;channels&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;timeout&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">3600</span>
 <span class="p">}</span>
 </code></pre></div>
 

--- a/templates/docs/apiv1.md
+++ b/templates/docs/apiv1.md
@@ -23,6 +23,7 @@ Endpoint Name                                         | Endpoint Address
 [Update an existing check](#update-check)             | `POST SITE_ROOT/api/v1/checks/<uuid>`
 [Pause monitoring of a check](#pause-check)           | `POST SITE_ROOT/api/v1/checks/<uuid>/pause`
 [Resume monitoring of a check](#resume-check)         | `POST SITE_ROOT/api/v1/checks/<uuid>/resume`
+[Clear a check's events](#clear-check-events)          | `POST SITE_ROOT/api/v1/checks/<uuid>/events/clear`
 [Delete check](#delete-check)                         | `DELETE SITE_ROOT/api/v1/checks/<uuid>`
 **Pings**|
 [List check's logged pings](#list-pings)              | `GET SITE_ROOT/api/v1/checks/<uuid>/pings/`
@@ -1061,6 +1062,77 @@ header is sometimes required by some network proxies and web servers.
 ```
 
 
+## Clear a Check's Events {: #clear-check-events .rule }
+
+`POST SITE_ROOT/api/v1/checks/<uuid>/events/clear`
+
+Clears all logged events for a check. This resets the check's state and deletes
+associated pings, notifications, and status changes.
+
+This API call has no request parameters.
+
+### Response Codes
+
+200 OK
+:   The events were successfully cleared.
+
+401 Unauthorized
+:   The API key is either missing or invalid.
+
+403 Forbidden
+:   Access denied, wrong API key.
+
+404 Not Found
+:   The specified check does not exist.
+
+### Example Request
+
+```bash
+curl SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/events/clear \
+    --request POST --header "X-Api-Key: your-api-key" --data ""
+```
+
+Note: the `--data ""` argument forces curl to send a `Content-Length` request header
+even though the request body is empty. For HTTP POST requests, the `Content-Length`
+header is sometimes required by some network proxies and web servers.
+
+### Example Response
+
+```json
+{
+  "name": "Backups",
+  "slug": "",
+  "tags": "prod www",
+  "desc": "",
+  "grace": 60,
+  "n_pings": 0,
+  "status": "new",
+  "started": false,
+  "last_ping": null,
+  "next_ping": null,
+  "manual_resume": false,
+  "methods": "",
+  "subject": "",
+  "subject_fail": "",
+  "start_kw": "",
+  "success_kw": "",
+  "failure_kw": "",
+  "filter_subject": false,
+  "filter_body": false,
+  "filter_http_body": false,
+  "filter_default_fail": false,
+  "badge_url": "SITE_ROOT/b/2/d43c84db-1502-4d86-a89d-181a33e25896.svg",
+  "uuid": "7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "ping_url": "PING_ENDPOINT7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "update_url": "SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "pause_url": "SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/pause",
+  "resume_url": "SITE_ROOT/api/v1/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume",
+  "channels": "",
+  "timeout": 3600
+}
+```
+
+
 ## Delete Check {: #delete-check .rule }
 
 `DELETE SITE_ROOT/api/v1/checks/<uuid>`
@@ -1421,4 +1493,3 @@ curl --header "X-Api-Key: your-api-key" SITE_ROOT/api/v1/badges/
   }
 }
 ```
-

--- a/templates/docs/apiv2.html-fragment
+++ b/templates/docs/apiv2.html-fragment
@@ -47,6 +47,10 @@ in your account.</p>
 <td><code>POST SITE_ROOT/api/v2/checks/&lt;uuid&gt;/resume</code></td>
 </tr>
 <tr>
+<td><a href="#clear-check-events">Clear a check's events</a></td>
+<td><code>POST SITE_ROOT/api/v2/checks/&lt;uuid&gt;/events/clear</code></td>
+</tr>
+<tr>
 <td><a href="#delete-check">Delete check</a></td>
 <td><code>DELETE SITE_ROOT/api/v2/checks/&lt;uuid&gt;</code></td>
 </tr>
@@ -955,6 +959,64 @@ header is sometimes required by some network proxies and web servers.</p>
 <span class="w">  </span><span class="nt">&quot;tags&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;prod www&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;timeout&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">3600</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;update_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v2/checks/f618072a-7bde-4eee-af63-71a77c5723bc&quot;</span>
+<span class="p">}</span>
+</code></pre></div>
+
+<h2 class="rule" id="clear-check-events">Clear a Check's Events</h2>
+<p><code>POST SITE_ROOT/api/v2/checks/&lt;uuid&gt;/events/clear</code></p>
+<p>Clears all logged events for a check. This resets the check's state and deletes
+associated pings, notifications, and status changes.</p>
+<p>This API call has no request parameters.</p>
+<h3>Response Codes</h3>
+<dl>
+<dt>200 OK</dt>
+<dd>The events were successfully cleared.</dd>
+<dt>401 Unauthorized</dt>
+<dd>The API key is either missing or invalid.</dd>
+<dt>403 Forbidden</dt>
+<dd>Access denied, wrong API key.</dd>
+<dt>404 Not Found</dt>
+<dd>The specified check does not exist.</dd>
+</dl>
+<h3>Example Request</h3>
+<div class="highlight"><pre><span></span><code>curl<span class="w"> </span>SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/events/clear<span class="w"> </span><span class="se">\</span>
+<span class="w">    </span>--request<span class="w"> </span>POST<span class="w"> </span>--header<span class="w"> </span><span class="s2">&quot;X-Api-Key: your-api-key&quot;</span><span class="w"> </span>--data<span class="w"> </span><span class="s2">&quot;&quot;</span>
+</code></pre></div>
+
+<p>Note: the <code>--data ""</code> argument forces curl to send a <code>Content-Length</code> request header
+even though the request body is empty. For HTTP POST requests, the <code>Content-Length</code>
+header is sometimes required by some network proxies and web servers.</p>
+<h3>Example Response</h3>
+<div class="highlight"><pre><span></span><code><span class="p">{</span>
+<span class="w">  </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Backups&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;slug&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;tags&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;prod www&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;desc&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;grace&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">60</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;n_pings&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">0</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;status&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;new&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;started&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;last_ping&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;next_ping&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;manual_resume&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;methods&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;subject&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;subject_fail&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;start_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;success_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;failure_kw&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_subject&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_body&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_http_body&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;filter_default_fail&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;badge_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/b/2/d43c84db-1502-4d86-a89d-181a33e25896.svg&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;uuid&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;ping_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;PING_ENDPOINT7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;update_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;pause_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/pause&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;resume_url&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;channels&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;timeout&quot;</span><span class="p">:</span><span class="w"> </span><span class="mi">3600</span>
 <span class="p">}</span>
 </code></pre></div>
 

--- a/templates/docs/apiv2.md
+++ b/templates/docs/apiv2.md
@@ -23,6 +23,7 @@ Endpoint Name                                         | Endpoint Address
 [Update an existing check](#update-check)             | `POST SITE_ROOT/api/v2/checks/<uuid>`
 [Pause monitoring of a check](#pause-check)           | `POST SITE_ROOT/api/v2/checks/<uuid>/pause`
 [Resume monitoring of a check](#resume-check)         | `POST SITE_ROOT/api/v2/checks/<uuid>/resume`
+[Clear a check's events](#clear-check-events)          | `POST SITE_ROOT/api/v2/checks/<uuid>/events/clear`
 [Delete check](#delete-check)                         | `DELETE SITE_ROOT/api/v2/checks/<uuid>`
 **Pings**|
 [List check's logged pings](#list-pings)              | `GET SITE_ROOT/api/v2/checks/<uuid>/pings/`
@@ -1091,6 +1092,77 @@ header is sometimes required by some network proxies and web servers.
 ```
 
 
+## Clear a Check's Events {: #clear-check-events .rule }
+
+`POST SITE_ROOT/api/v2/checks/<uuid>/events/clear`
+
+Clears all logged events for a check. This resets the check's state and deletes
+associated pings, notifications, and status changes.
+
+This API call has no request parameters.
+
+### Response Codes
+
+200 OK
+:   The events were successfully cleared.
+
+401 Unauthorized
+:   The API key is either missing or invalid.
+
+403 Forbidden
+:   Access denied, wrong API key.
+
+404 Not Found
+:   The specified check does not exist.
+
+### Example Request
+
+```bash
+curl SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/events/clear \
+    --request POST --header "X-Api-Key: your-api-key" --data ""
+```
+
+Note: the `--data ""` argument forces curl to send a `Content-Length` request header
+even though the request body is empty. For HTTP POST requests, the `Content-Length`
+header is sometimes required by some network proxies and web servers.
+
+### Example Response
+
+```json
+{
+  "name": "Backups",
+  "slug": "",
+  "tags": "prod www",
+  "desc": "",
+  "grace": 60,
+  "n_pings": 0,
+  "status": "new",
+  "started": false,
+  "last_ping": null,
+  "next_ping": null,
+  "manual_resume": false,
+  "methods": "",
+  "subject": "",
+  "subject_fail": "",
+  "start_kw": "",
+  "success_kw": "",
+  "failure_kw": "",
+  "filter_subject": false,
+  "filter_body": false,
+  "filter_http_body": false,
+  "filter_default_fail": false,
+  "badge_url": "SITE_ROOT/b/2/d43c84db-1502-4d86-a89d-181a33e25896.svg",
+  "uuid": "7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "ping_url": "PING_ENDPOINT7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "update_url": "SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79",
+  "pause_url": "SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/pause",
+  "resume_url": "SITE_ROOT/api/v2/checks/7918b17b-a745-4db1-8575-9d2e07c97f79/resume",
+  "channels": "",
+  "timeout": 3600
+}
+```
+
+
 ## Delete Check {: #delete-check .rule }
 
 `DELETE SITE_ROOT/api/v2/checks/<uuid>`
@@ -1452,4 +1524,3 @@ curl --header "X-Api-Key: your-api-key" SITE_ROOT/api/v2/badges/
   }
 }
 ```
-


### PR DESCRIPTION
This PR adds a new Management API endpoint to clear a check's events, mirroring the existing "Clear Events" functionality available in the web interface.

**Endpoint**: POST `/api/v{1,2,3}/checks/<uuid>/events/clear`

**Details** → This endpoint resets a check's state and removes all associated event data:
- Sets status to `new`
- Clears `last_ping`, `last_start`, `last_duration`, `alert_after`
- Resets the check to a fresh `new` state (clears all ping-related metadata, deletes pings, notifications, and flips)

The implementation matches the behavior of the web UI's "Clear Events" action (hc/front/views.py:858-875).

**Changes**
- `hc/api/urls.py` - Added route
- `hc/api/views.py` - Added clear_events view
- `hc/api/tests/test_clear_events.py` - Added 8 test cases
- `templates/docs/api*.md` and `templates/docs/api*.html-fragment` - Added documentation for v1, v2, and v3

**Testing**
- All existing tests pass
- New tests cover: basic functionality, API key in POST body, OPTIONS handling, POST-only validation, ownership validation, invalid UUID, missing check, non-dict body rejection